### PR TITLE
Add bpftrace to buildall and updateall

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -541,16 +541,28 @@ function update_upstream_from_source_package() {
 function update_upstream_from_git() {
 	check_env UPSTREAM_GIT_URL UPSTREAM_GIT_BRANCH
 	logmust cd "$WORKDIR/repo"
-	check_git_ref "remotes/origin/$REPO_UPSTREAM_BRANCH" repo-HEAD
+	check_git_ref "remotes/origin/$REPO_UPSTREAM_BRANCH"
 
+	#
+	# checkout our local branch that tracks upstream.
+	#
+	logmust git checkout -q -b upstream-HEAD \
+		"remotes/origin/$REPO_UPSTREAM_BRANCH"
+
+	#
+	# Fetch updates from third-party upstream repository.
+	#
 	logmust git remote add upstream "$UPSTREAM_GIT_URL"
 	logmust git fetch upstream "$UPSTREAM_GIT_BRANCH"
 
-	if git diff --cached --quiet FETCH_HEAD \
+	#
+	# Compare third-party upstream repository to our local snapshot of the
+	# upstream repository.
+	#
+	if git diff --quiet FETCH_HEAD \
 		"remotes/origin/$REPO_UPSTREAM_BRANCH"; then
 		echo "NOTE: upstream for $PACKAGE is already up-to-date."
 	else
-		logmust git checkout -q repo-HEAD
 		#
 		# Note we do --ff-only here which will fail if upstream has
 		# been rebased. We always want this behaviour as a rebase

--- a/package-lists/buildall.pkgs
+++ b/package-lists/buildall.pkgs
@@ -3,12 +3,10 @@
 # be available to appliance-build.
 #
 
+bpftrace
 cloud-init
 connstat
 delphix-kernel
 delphix-platform
 python-rtslib-fb
 targetcli-fb
-
-# Uncomment once Delphix repositories are created
-#bpftrace

--- a/package-lists/updateall.pkgs
+++ b/package-lists/updateall.pkgs
@@ -5,6 +5,7 @@
 # auto-merge-blacklist.pkg.
 #
 
+bpftrace
 cloud-init
 python-rtslib-fb
 targetcli-fb

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -19,7 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bpftrace.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
-UPSTREAM_GIT_URL="https://github.com/iovisor/bpftrace"
+UPSTREAM_GIT_URL="https://github.com/iovisor/bpftrace.git"
 UPSTREAM_GIT_BRANCH="master"
 
 function prepare() {


### PR DESCRIPTION
This adds `bpftrace` package to the official linux-pkg package bundle.
It also adds `bpftrace` to the auto-update checker. I've also fixed broken logic in `update_upstream_from_git()`. Note that this function was only used by `bpftrace` so far since the other third-party packages use `update_upstream_from_source_package()` instead.

Note that this change doesn't add `bpftrace` to the appliance; for that bpftrace will need to be added as a dependency of `delphix-platform`.

**TESTING**
- build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/10/console
- update (no updates performed): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/update/5/console
- manually ran `updateall.sh` against private bpftrace repo to test auto-update.
- manually tested that the bpftrace package works as expected