### PR TITLE
Add package definition for make-jpkg

### DIFF
--- a/packages/make-jpkg/config.sh
+++ b/packages/make-jpkg/config.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/make-jpkg.git"
+# Note we auto-detect version in build()
+
+UPSTREAM_GIT_URL=https://salsa.debian.org/java-team/java-package.git
+UPSTREAM_GIT_BRANCH=master
+
+function build() {
+	# Auto-detect version from upstream.
+	# Make sure it is a base version, without revision.
+	logmust cd "$WORKDIR/repo"
+	PACKAGE_VERSION=$(dpkg-parsechangelog --show-field Version)
+	if [[ "$PACKAGE_VERSION" == *-* ]]; then
+		die "Bad package version '$PACKAGE_VERSION': should not contain '-'"
+	fi
+
+	logmust dpkg_buildpackage_default
+	logmust store_git_info
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
This adds a package definition for `make-jpkg`.
Note that with this change this package will not be built or updated automatically.

## TESTING
- Ran `make check`
- Build with `./buildpkg.sh make-jpkg` and installed produced package on a `bootstrap-18-04` system:
```
$ apt show java-package
Package: java-package
Version: 0.63-delphix-2019.01.16.19
Status: install ok installed
Priority: optional
Section: contrib/misc
Maintainer: Debian Java Maintainers <pkg-java-maintainers@lists.alioth.debian.org>
Installed-Size: 71.7 kB
Depends: debhelper (>= 11), build-essential, dpkg-dev, fakeroot, libasound2, libfontconfig1, libgl1-mesa-glx, libgtk2.0-0, libx11-6, libxslt1.1, libxtst6, libxxf86vm1, unzip
Suggests: openjdk-8-jre
Download-Size: unknown
APT-Manual-Installed: yes
APT-Sources: /var/lib/dpkg/status
Description: Utility for creating Java Debian packages
 This package provides the capability to build a Debian package from
 a Java binary distribution by running make-jpkg <java binary archive file>.
 (with archive files downloaded from providers listed below)
 .
 Supported java binary distributions currently include:
   * Oracle (http://www.oracle.com/technetwork/java/javase/downloads) :
     - The Java Development Kit (JDK), version 6, 7 and 8
     - The Java Runtime Environment (JRE), version 6, 7 and 8
     - The Java API Javadoc, version 6, 7 and 8
 Choose tar.gz archives or self-extracting archives (_not_ RPM).
 .
 Please note that Debian recommends the use of openjdk-[78]-jdk and/or
 openjdk-[78]-jre, which are installed by default-jdk or default-jre for
 most architectures.
 .
 java-package will create non-free packages.
```