### PR TITLE
Add bcc and have bpftrace depend on it

### DIFF
--- a/package-lists/buildall.pkgs
+++ b/package-lists/buildall.pkgs
@@ -3,6 +3,10 @@
 # be available to appliance-build.
 #
 
+# Note: bcc should be built before bpftrace since it provides libbcc which is
+# required to build bpftrace.
+bcc
+
 bpftrace
 cloud-init
 connstat

--- a/package-lists/updateall.pkgs
+++ b/package-lists/updateall.pkgs
@@ -5,6 +5,12 @@
 # auto-merge-blacklist.pkg.
 #
 
+# Note: we do not auto-update bcc for now as upstream tends to introduce
+# changes that break bpftrace. Instead, we manually update to tagged versions.
+# In the future we may want to automatically determine the latest tag and
+# auto-update to that.
+#bcc
+
 bpftrace
 cloud-init
 python-rtslib-fb

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright 2018 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bcc.git"
+
+UPSTREAM_GIT_URL=https://github.com/iovisor/bcc.git
+UPSTREAM_GIT_BRANCH=master
+
+function prepare() {
+	logmust install_pkgs \
+		arping \
+		bison \
+		build-essential \
+		clang-format-6.0 \
+		cmake \
+		flex \
+		git \
+		iperf \
+		libclang-6.0-dev \
+		libedit-dev \
+		libelf-dev \
+		libllvm6.0 \
+		llvm-6.0-dev \
+		luajit \
+		luajit-5.1-dev \
+		netperf \
+		python \
+		python-netaddr \
+		python-pyroute2 \
+		zlib1g-dev
+}
+
+function build() {
+	logmust cd "$WORKDIR/repo"
+	# Note: the string to determine the version was copied from bcc's
+	# debian/rules file.
+	PACKAGE_VERSION=$(dpkg-parsechangelog | sed -rne "s,^Version: (.*),\1,p")
+
+	logmust dpkg_buildpackage_default
+	logmust store_git_info
+
+	# Install libbcc which is required to build bpftrace
+	logmust install_pkgs "$WORKDIR/artifacts"/libbcc_*.deb
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -23,6 +23,10 @@ UPSTREAM_GIT_URL="https://github.com/iovisor/bpftrace.git"
 UPSTREAM_GIT_BRANCH="master"
 
 function prepare() {
+	if ! dpkg-query --show libbcc >/dev/null 2>&1; then
+		echo_bold "libbcc not installed. Building package 'bcc' first."
+		logmust $TOP/buildpkg.sh bcc
+	fi
 
 	#
 	# Due to a bug in Ubuntu's version of Clang we need to fetch the packages


### PR DESCRIPTION
This adds bcc to linux-pkg.

This depends on https://github.com/delphix/bcc/pull/1 and https://github.com/delphix/delphix-platform/pull/40

## TESTING
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/27/
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/417/ (Failed due to conflict with libbpfcc)

Added dependency on https://github.com/delphix/delphix-platform/pull/40:
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/30/
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/419/ (Pass, except for DLPX-62465)