### PR TITLE
Allow fetching refs for package repositories

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -473,11 +473,12 @@ function default_revision() {
 function fetch_repo_from_git() {
 	check_env PACKAGE_GIT_URL PACKAGE_GIT_BRANCH
 
-	logmust cd "$WORKDIR"
-	logmust git clone --branch "$PACKAGE_GIT_BRANCH" "$PACKAGE_GIT_URL" \
-		repo
+	logmust mkdir "$WORKDIR/repo"
 	logmust cd "$WORKDIR/repo"
-	logmust git checkout -b repo-HEAD HEAD
+	logmust git init
+	logmust git fetch --no-tags "$PACKAGE_GIT_URL" \
+		"+$PACKAGE_GIT_BRANCH:repo-HEAD" --depth=1
+	logmust git checkout repo-HEAD
 }
 
 function generate_commit_message_from_dsc() {

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -49,7 +49,7 @@ function build() {
 	logmust cd "$WORKDIR/repo"
 	# Note: the string to determine the version was copied from bcc's
 	# debian/rules file.
-	PACKAGE_VERSION=$(dpkg-parsechangelog | sed -rne "s,^Version: (.*),\1,p")
+	PACKAGE_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1,p')
 
 	logmust dpkg_buildpackage_default
 	logmust store_git_info

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -25,7 +25,7 @@ UPSTREAM_GIT_BRANCH="master"
 function prepare() {
 	if ! dpkg-query --show libbcc >/dev/null 2>&1; then
 		echo_bold "libbcc not installed. Building package 'bcc' first."
-		logmust $TOP/buildpkg.sh bcc
+		logmust "$TOP/buildpkg.sh" bcc
 	fi
 
 	#


### PR DESCRIPTION
Without this, we can only specify branches or tags when fetching the source for building a package.
With this, we can specify references like `refs/heads/master`.

This work is needed for `git-ab-pre-push` to work with repositories managed by linux-pkg.

## TESTING
* linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/50
* linux-pkg-build with ref passed as branch: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/51
* make check