### PR TITLE
Coloring in dpkg-buildpackage is broken when output in Jenkins

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -24,7 +24,6 @@ export REPO_UPSTREAM_BRANCH="upstreams/master"
 
 # shellcheck disable=SC2086
 function enable_colors() {
-	export DPKG_COLORS="always"
 	[[ -t 1 ]] && flags="" || flags="-T xterm"
 	FMT_RED="$(tput $flags setaf 1)"
 	FMT_GREEN="$(tput $flags setaf 2)"
@@ -34,7 +33,6 @@ function enable_colors() {
 }
 
 function disable_colors() {
-	unset DPKG_COLORS
 	FMT_RED=""
 	FMT_GREEN=""
 	FMT_BOLD=""

--- a/packages/ptools/config.sh
+++ b/packages/ptools/config.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/ptools.git"
 
@@ -23,7 +24,7 @@ function prepare() {
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	PACKAGE_VERSION=$(sed -rn 's/version = "(.*)"/\1/p' < Cargo.toml)
+	PACKAGE_VERSION=$(sed -rn 's/version = "(.*)"/\1/p' <Cargo.toml)
 
 	logmust dpkg_buildpackage_default
 }


### PR DESCRIPTION
We want to stop coloring the output of `dpkg-buildpackage` when ran from Jenkins as it causes coloring issues when building certain packages (e.g. `bcc`). Another side-effect of coloring issues is that invisible characters can get copied along when copying Jenkins console strings.

## Testing
- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/69
- make check