### PR TITLE
 Retry multiple times when installing package dependencies

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -406,7 +406,7 @@ function install_pkgs() {
 		echo "apt-get install failed, retrying."
 		sleep 10
 	done
-	echo_error "apt-get install failed after $attempt attempts"
+	die "apt-get install failed after $attempt attempts"
 }
 
 function install_source_package_build_deps() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -398,7 +398,15 @@ function get_package_config_from_env() {
 }
 
 function install_pkgs() {
-	logmust sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
+	for attempt in {1..3}; do
+		echo "Running: sudo env DEBIAN_FRONTEND=noninteractive " \
+			"apt-get install -y $*"
+		sudo env DEBIAN_FRONTEND=noninteractive apt-get install \
+			-y "$@" && return
+		echo "apt-get install failed, retrying."
+		sleep 10
+	done
+	echo_error "apt-get install failed after $attempt attempts"
 }
 
 function install_source_package_build_deps() {

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -20,23 +20,21 @@ DEFAULT_PACKAGE_GIT_URL=none
 tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz"
 
 function prepare() {
-        logmust $TOP/buildpkg.sh make-jpkg
+	logmust "$TOP/buildpkg.sh" make-jpkg
 }
 
 function fetch() {
-        logmust cd "$WORKDIR/"
+	logmust cd "$WORKDIR/"
 
-        local url="http://artifactory.delphix.com/artifactory"
+	local url="http://artifactory.delphix.com/artifactory"
 
-        wget -nv "$url/java-binaries/linux/jdk/8/$tarfile" -O "$tarfile"
+	wget -nv "$url/java-binaries/linux/jdk/8/$tarfile" -O "$tarfile"
 }
 
 function build() {
-        logmust cd "$WORKDIR/"
+	logmust cd "$WORKDIR/"
 
-        env DEB_BUILD_OPTIONS=nostrip \
-          fakeroot make-jpkg "$tarfile" <<<y
+	env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
 
-        logmust mv ./*.deb artifacts/
-        rm -r ./*.tar.gz
+	logmust mv ./*.deb artifacts/
 }


### PR DESCRIPTION
Since we've seen a few issues when fetching packages from external repositories (e.g. #7), this should hopefully help us in case there are intermittent issues.

## TESTING
- linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/96/
- make check
- negative test installing broken dependencies: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/117/console