### PR TITLE
add Java 8

### DIFF
--- a/package-lists/buildall.pkgs
+++ b/package-lists/buildall.pkgs
@@ -3,9 +3,12 @@
 # be available to appliance-build.
 #
 
-# Note: bcc should be built before bpftrace since it provides libbcc which is
-# required to build bpftrace.
+# Note: The following packages should be built first be cause other packages
+# depend on them being built.
+#  - bcc is required by bpftrace
+#  - java8 is required by the saml app
 bcc
+java8
 
 bpftrace
 cloud-init

--- a/packages/java8/config.sh
+++ b/packages/java8/config.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL=none
+
+tarfile="jdk-8u171-linux-x64.tar.gz"
+jdk_path="/usr/lib/jvm/oracle-java8-jdk-amd64"
+
+function prepare() {
+	logmust install_pkgs java-package
+}
+
+function fetch() {
+	logmust cd "$WORKDIR"
+	local url="http://artifactory.delphix.com/artifactory"
+	logmust wget -nv "$url/java-binaries/linux/jdk/8/$tarfile" -O "$tarfile"
+}
+
+function build() {
+	logmust cd "$WORKDIR"
+	logmust env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
+	logmust mv ./*.deb "$WORKDIR/artifacts/"
+	#
+	# Store the install path of the JDK in a file so that the users of this
+	# Java package know where to look. This is especially useful for
+	# other linux-pkg packages that have a build dependency on this
+	# particular version of Java, as they don't have to hardcode the
+	# path in their build definition. This would also be useful if external
+	# packages, such as the app-gate, decide to fetch and install Java from
+	# the Linux-pkg bundle.
+	#
+	logmust bash -c "echo $jdk_path >'$WORKDIR/artifacts/JDK_PATH'"
+	#
+	# Install the Java package on this system so that other linux-pkg
+	# packages can use it.
+	#
+	logmust install_pkgs "$WORKDIR/artifacts/"*.deb
+}


### PR DESCRIPTION
Add Java 8 package to Linux-pkg.
The main goal here is to stop building Java in appliance-build and do it in Linux-pkg instead. This is also a prerequisite for adding the SSO app to Linux-pkg.

## NEXT STEPS
Remove Java build from appliance-build

## TESTING
* linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/pre-push/144/
* ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/651/
* make check
* Tested manually building with the SSO app