### PR TITLE
TOOL-7381 linux-pkg userland build list should not build kernel modules

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -12,9 +12,6 @@ java8
 delphix-sso-app
 bpftrace
 cloud-init
-# TOOL-7381: remove connstat and delphix-kernel from this list
-connstat
-delphix-kernel
 delphix-platform
 python-rtslib-fb
 targetcli-fb


### PR DESCRIPTION
## PROJECT

This change is part of the PHASE 2 of the linux-pkg build list project here (Step 15):
https://jira.delphix.com/browse/TOOL-7378

Here is a spreadsheet that shows the dependencies for this commit:
https://docs.google.com/spreadsheets/d/1-qRT4esBl0827wKCpsNe8veXJnH2s8k1fWr20me260Q

## DESCRIPTION

Since we are now using the kernel package list in appliance-build, we no longer want to build kernel packages as part of the userland package list.

## TESTING

1. Build userland and kernel package lists:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/1/
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/2/
2. Use the build artifacts to generate a new appliance (Note that testing includes work from TOOL-7382 and TOOL-7383):
http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/38/
