### PR TITLE
Add checkstyle hook for ZFS

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -55,6 +55,16 @@ function prepare() {
 	logmust install_kernel_headers
 }
 
+function checkstyle() {
+	logmust cd "$WORKDIR/repo"
+	logmust sh autogen.sh
+	logmust ./configure --with-config=user
+	logmust install_pkgs flake8 mandoc
+	logmust make codecheck
+	logmust git reset --hard HEAD
+	logmust git clean -qdxf
+}
+
 function build() {
 	logmust cd "$WORKDIR/repo"
 


### PR DESCRIPTION
This will allow us to require `zfs-precommit` and `git-ab-pre-push` to run checkstyle on ZFS changes later on. Right now, this can be ran manually by setting checking `CHECKSTYLE` in the Jenkins build job (See job in testing section), or by running `./buildpkg -c zfs` in `linux-pkg`.

## TESTING

- http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/2/
- make check