### PR TITLE
 Add adoptopenjdk to userland list

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -7,6 +7,7 @@
 #  - bcc is required by bpftrace
 #  - java8 is required by the saml app
 bcc
+java8
 make-jpkg
 adoptopenjdk
 

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -7,7 +7,8 @@
 #  - bcc is required by bpftrace
 #  - java8 is required by the saml app
 bcc
-java8
+make-jpkg
+adoptopenjdk
 
 delphix-sso-app
 bpftrace

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -21,7 +21,7 @@ tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz"
 jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 
 function prepare() {
-	if [[ $(dpkg-query --show java-package) != *"delphix"* ]]; then
+	if [ ! -f "$TOP/packages/make-jpkg/tmp/artifacts/"*.deb ]; then
 		echo_bold "custom java-package not installed. Building package 'make-jpkg' first."
 		logmust "$TOP/buildpkg.sh" make-jpkg
 	fi
@@ -38,7 +38,7 @@ function fetch() {
 function build() {
 	logmust cd "$WORKDIR/"
 
-	env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
+	logmust env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
 
 	logmust mv ./*.deb "$WORKDIR/artifacts/"
 	#

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -21,7 +21,7 @@ tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz"
 jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 
 function prepare() {
-	if [ ! -f "$TOP/packages/make-jpkg/tmp/artifacts/"*.deb ]; then
+	if ! ls "$TOP/packages/make-jpkg/tmp/artifacts/"*.deb >/dev/null 2>&1; then
 		echo_bold "custom java-package not installed. Building package 'make-jpkg' first."
 		logmust "$TOP/buildpkg.sh" make-jpkg
 	fi

--- a/packages/delphix-sso-app/config.sh
+++ b/packages/delphix-sso-app/config.sh
@@ -17,13 +17,13 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/app/saml-app.git"
-JDK_PATH_FILE="$TOP/packages/java8/tmp/artifacts/JDK_PATH"
+JDK_PATH_FILE="$TOP/packages/adoptopenjdk/tmp/artifacts/JDK_PATH"
 
 function prepare() {
-	java_package_exists=$(dpkg-query --show oracle-java8-jdk >/dev/null 2>&1)
+	java_package_exists=$(dpkg-query --show adoptopenjdk-java8-jdk >/dev/null 2>&1)
 	if [[ ! $java_package_exists && ! -f $JDK_PATH_FILE ]]; then
-		echo_bold "java8 not installed. Building package 'java8' first."
-		logmust "$TOP/buildpkg.sh" java8
+		echo_bold "java8 not installed. Building package 'adoptopenjdk' first."
+		logmust "$TOP/buildpkg.sh" adoptopenjdk
 	fi
 }
 


### PR DESCRIPTION
AdoptopenJDK is added to the userland build list for virtualization and masking.
once changes for Virtualization and Masking are pushed, `java8` can safely be removed from the list.

**Testing:**
added adoptopenjdk-java8 as dependency in app-gate instead of oracle-java8 -> ran pre-push -> http://selfservice.jenkins.delphix.com/job/dlpx-app-gate/job/master/job/build-package/job/pre-push/412/

pre-push for linux-pkg with adoptopenjdk changes -> http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/8/

appliance-build-orchestrator-pre-push with S3 links from above runs -> http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/766/