### PR TITLE
add bpftrace build dependency systemtap-sdt-dev

### DIFF
--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -63,7 +63,8 @@ function prepare() {
 		libllvm5.0 \
 		llvm-5.0 \
 		llvm-5.0-dev \
-		llvm-5.0-runtime
+		llvm-5.0-runtime \
+		systemtap-sdt-dev
 }
 
 function build() {


### PR DESCRIPTION
Upstream has added a new build dependency on `systemtap-sdt-dev`.
This causes build failures on an attempt to merge with upstream.

## TESTING
- linux-pkg-build with bpftrace merged with upstream:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/27/console
- make check