### PR TITLE
Update default td-agent package base version to 3.4.0

### DIFF
--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -18,8 +18,8 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/omnibus-td-agent.git"
 
-# We're customizing td-agent version 3.3.0
-DEFAULT_PACKAGE_VERSION=3.3.0
+# We're customizing td-agent version 3.4.0
+DEFAULT_PACKAGE_VERSION=3.4.0
 
 UPSTREAM_GIT_URL=https://github.com/treasure-data/omnibus-td-agent.git
 UPSTREAM_GIT_BRANCH=master


### PR DESCRIPTION
Upstream `td-agent` package version was updated to 3.4.0 and I've fixed our custom td-agent package's upstream merge via - https://github.com/delphix/omnibus-td-agent/pull/2

This PR is to update the corresponding base version in `td-agent` package build to 3.4.0
