### PR TITLE
upgrade java to 8u212

### DIFF
--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -17,7 +17,7 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL=none
-tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz"
+tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u212b04.tar.gz"
 jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 
 function prepare() {


### PR DESCRIPTION
Related Reviews:
app-gate: http://reviews.delphix.com/r/50102/
masking: http://reviews.delphix.com/r/50104/

linux pre-push - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/138/

appliance-build-orchestrator-pre-push -  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1362/

Verification on image from ab-pre-push:
```delphix@ip-10-110-253-34:~$ java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.212-b04, mixed mode)
delphix@ip-10-110-253-34:~$ javac -version
javac 1.8.0_212
```