### PR TITLE
Update current version to 3.4.1

### DIFF
--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -17,9 +17,7 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/omnibus-td-agent.git"
-
-# We're customizing td-agent version 3.4.1
-DEFAULT_PACKAGE_VERSION=3.4.1
+# Note: we get the package version programatically in build()
 
 UPSTREAM_GIT_URL=https://github.com/treasure-data/omnibus-td-agent.git
 UPSTREAM_GIT_BRANCH=master
@@ -33,6 +31,9 @@ function prepare() {
 
 function build() {
 	logmust cd "$WORKDIR/repo"
+	if [[ -z "$PACKAGE_VERSION" ]]; then
+		logmust eval PACKAGE_VERSION="$(grep build_version ./config/projects/td-agent3.rb | head -1 | awk '{ print $2; }')"
+	fi
 	# Ensure all required gems are installed
 	logmust bundle install --binstubs
 	# Download dependent gems using downloader

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -18,8 +18,8 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/omnibus-td-agent.git"
 
-# We're customizing td-agent version 3.4.0
-DEFAULT_PACKAGE_VERSION=3.4.0
+# We're customizing td-agent version 3.4.1
+DEFAULT_PACKAGE_VERSION=3.4.1
 
 UPSTREAM_GIT_URL=https://github.com/treasure-data/omnibus-td-agent.git
 UPSTREAM_GIT_BRANCH=master


### PR DESCRIPTION
Upstream `td-agent` package version was updated to 3.4.1 and I've updated our down stream `td-agent` plugins to match that via - https://github.com/delphix/omnibus-td-agent/pull/4

So, this PR just updates our corresponding `td-agent` package version to 3.4.1 to reflect the same.


