### PR TITLE
Allow fetching previously built artifacts from S3

### DIFF
--- a/buildlist.sh
+++ b/buildlist.sh
@@ -46,6 +46,7 @@ pkg_list_file="$_RET"
 logmust cd "$TOP"
 logmust make clean
 logmust mkdir artifacts
+logmust mkdir artifacts/cache
 
 #
 # Auto-generate the default revision for all the packages. It will be the
@@ -87,6 +88,19 @@ logmust cp build-info-pkg/artifacts/* artifacts/
 
 for pkg in "${PACKAGES[@]}"; do
 	logmust cp "packages/$pkg/tmp/artifacts"/* artifacts/
+
+	#
+	# Cache each package's artifacts in a separate directory so that they
+	# can be easily retrieved by future linux-pkg builds. Note that those
+	# artifacts are not consumed by appliance-build.
+	#
+	logmust mkdir -p "artifacts/cache/$pkg/artifacts"
+	logmust cp "packages/$pkg/tmp/artifacts"/* \
+		"artifacts/cache/$pkg/artifacts/"
+	if [[ -f "packages/$pkg/tmp/build_info" ]]; then
+		logmust cp "packages/$pkg/tmp/build_info" \
+			"artifacts/cache/$pkg/"
+	fi
 done
 
 echo_success "Packages have been built successfully."

--- a/buildlist.sh
+++ b/buildlist.sh
@@ -81,11 +81,13 @@ PACKAGES=("${_RET_LIST[@]}")
 for pkg in "${PACKAGES[@]}"; do
 	# shellcheck disable=SC2086
 	logmust ./buildpkg.sh $build_flags "$pkg"
+	echo ""
 done
 
 logmust build-info-pkg/build-package.sh "$pkg_list"
 logmust cp build-info-pkg/artifacts/* artifacts/
 
+fetched_from_cache=false
 for pkg in "${PACKAGES[@]}"; do
 	logmust cp "packages/$pkg/tmp/artifacts"/* artifacts/
 
@@ -101,6 +103,19 @@ for pkg in "${PACKAGES[@]}"; do
 		logmust cp "packages/$pkg/tmp/build_info" \
 			"artifacts/cache/$pkg/"
 	fi
+	if [[ -f "packages/$pkg/tmp/fetched-from-cache" ]]; then
+		fetched_from_cache=true
+	fi
 done
+
+if $fetched_from_cache; then
+	echo_warn "The following package artifacts were not built, but" \
+		"fetched from $CACHED_ARTIFACTS_URL:"
+	for pkg in "${PACKAGES[@]}"; do
+		if [[ -f "packages/$pkg/tmp/fetched-from-cache" ]]; then
+			echo_warn " - $pkg"
+		fi
+	done
+fi
 
 echo_success "Packages have been built successfully."

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -27,6 +27,7 @@ function enable_colors() {
 	[[ -t 1 ]] && flags="" || flags="-T xterm"
 	FMT_RED="$(tput $flags setaf 1)"
 	FMT_GREEN="$(tput $flags setaf 2)"
+	FMT_YELLOW="$(tput $flags setaf 3)"
 	FMT_BOLD="$(tput $flags bold)"
 	FMT_NF="$(tput $flags sgr0)"
 	COLORS_ENABLED=true
@@ -35,6 +36,7 @@ function enable_colors() {
 function disable_colors() {
 	FMT_RED=""
 	FMT_GREEN=""
+	FMT_YELLOW=""
 	FMT_BOLD=""
 	FMT_NF=""
 	COLORS_ENABLED=false
@@ -62,6 +64,10 @@ function echo_error() {
 
 function echo_success() {
 	echo -e "${FMT_BOLD}${FMT_GREEN}Success: $*${FMT_NF}"
+}
+
+function echo_warn() {
+	echo -e "${FMT_BOLD}${FMT_YELLOW}Warning: $*${FMT_NF}"
 }
 
 function echo_bold() {
@@ -325,13 +331,17 @@ function get_package_config_from_env() {
 
 	echo "get_package_config_from_env(): using prefix: ${PACKAGE_PREFIX}_"
 
+	export PACKAGE_CUSTOMIZED=false
+
 	var="${PACKAGE_PREFIX}_GIT_URL"
 	if [[ -n "$PARAM_PACKAGE_GIT_URL" ]]; then
 		PACKAGE_GIT_URL="$PARAM_PACKAGE_GIT_URL"
 		echo "PARAM_PACKAGE_GIT_URL passed from '-g'"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_GIT_URL="${!var}"
 		echo "PACKAGE_GIT_URL set to value of ${var}"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "$DEFAULT_PACKAGE_GIT_URL" ]]; then
 		PACKAGE_GIT_URL="$DEFAULT_PACKAGE_GIT_URL"
 		echo "PACKAGE_GIT_URL set to value of DEFAULT_PACKAGE_GIT_URL"
@@ -341,9 +351,11 @@ function get_package_config_from_env() {
 	if [[ -n "$PARAM_PACKAGE_GIT_BRANCH" ]]; then
 		PACKAGE_GIT_BRANCH="$PARAM_PACKAGE_GIT_BRANCH"
 		echo "PARAM_PACKAGE_GIT_BRANCH passed from '-b'"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_GIT_BRANCH="${!var}"
 		echo "PACKAGE_GIT_BRANCH set to value of ${var}"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "$DEFAULT_PACKAGE_GIT_BRANCH" ]]; then
 		PACKAGE_GIT_BRANCH="$DEFAULT_PACKAGE_GIT_BRANCH"
 		echo "PACKAGE_GIT_BRANCH set to value of" \
@@ -359,9 +371,11 @@ function get_package_config_from_env() {
 	if [[ -n "$PARAM_PACKAGE_VERSION" ]]; then
 		PACKAGE_VERSION="$PARAM_PACKAGE_VERSION"
 		echo "PACKAGE_VERSION passed from '-v'"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_VERSION="${!var}"
 		echo "PACKAGE_VERSION set to value of ${var}"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "$DEFAULT_PACKAGE_VERSION" ]]; then
 		PACKAGE_VERSION="$DEFAULT_PACKAGE_VERSION"
 		echo "PACKAGE_VERSION set to value of DEFAULT_PACKAGE_VERSION"
@@ -371,9 +385,11 @@ function get_package_config_from_env() {
 	if [[ -n "$PARAM_PACKAGE_REVISION" ]]; then
 		PACKAGE_REVISION="$PARAM_PACKAGE_REVISION"
 		echo "PACKAGE_REVISION passed from '-r'"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_REVISION="${!var}"
 		echo "PACKAGE_REVISION set to value of ${var}"
+		PACKAGE_CUSTOMIZED=true
 	elif [[ -n "$DEFAULT_PACKAGE_REVISION" ]]; then
 		PACKAGE_REVISION="$DEFAULT_PACKAGE_REVISION"
 		echo "PACKAGE_REVISION set to value of DEFAULT_PACKAGE_REVISION"


### PR DESCRIPTION
## DESCRIPTION

This gives us the ability to fetch artifacts for some packages from a previous build.

When we do so is dictated by the REUSE_CACHED_ARTIFACTS policy, which can have 3 possible values:
- "never": never re-use artifacts from previous builds. This is the default setting.
- "on-failure": build all packages as usual. If a package fails to build, then fetch it from a previous build.
- "always": fetch all packages from a previous build.

Note that if we pass custom parameters for a package (e.g. provide a custom git url or branch), then we will never re-use artifacts from a previous build.

The "previous build" URL will be passed by Jenkins (devops-gate change to be posted soon) and is the latest post-push build.

Note that linux-pkg will not attempt to compare the hash of previous packages to determine whether or not it should be rebuilt, nor will it care if linux-pkg itself has changed. This simplifies the logic a lot but puts the burden or determining when it is safe to use each setting on the developer that tests the changes.

## MOTIVATION

We've had intermittent external dependency errors such as https://github.com/delphix/linux-pkg/issues/20 and https://github.com/delphix/linux-pkg/issues/7 that prevent developers from testing their changes in other packages. This helps developers to avoid being affected by those errors unless they are making changes to the affected packages.

This will also give the ability to manually launch a post-push job with the "on-failure" setting, to avoid blocking teams that are waiting on some changes to be rolled-out.

By default, git-ab-pre-push will set the "on-failure" setting. As a bonus, we also have the "always" setting, which significantly speeds-up builds. We may decide to use this as the default setting if we deem it safe enough. In any case, we will add an option to pass this setting to git-ab-pre-push.

## TODO
- Add new parameters to documentation

## FOLLOW-UP WORK

- Changes to linux-pkg-build and ab-orchestrator jenkins jobs (tested already, will post soon)
- Changes to git-ab-pre-push (TODO)

## TESTING

- Manually tested various combinations of settings on a bootstrap VM
- Made sure that packages with custom parameters are always built regardless of settings
- Ran linux-pkg-build job with each setting:
  "always": http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/11/consoleFull
  "always", 1 custom package: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/13
  "on-failure": http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/14/parameters/
  "never": http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/16/parameters/

fixes https://github.com/delphix/linux-pkg/issues/27