### PR TITLE
add build definition for base-os-tools

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -6,22 +6,23 @@
 # depend on them being built.
 #  - bcc is required by bpftrace
 #  - java8 is required by the saml app
+adoptopenjdk
 bcc
 java8
 make-jpkg
-adoptopenjdk
 
-delphix-sso-app
+base-os-tools
 bpftrace
 challenge-response
 cloud-init
 crash-python
 crypt-blowfish
 delphix-platform
+delphix-sso-app
 drgn
 gdb-python
 libkdumpfile
+ptools
 python-rtslib-fb
 targetcli-fb
-ptools
 td-agent

--- a/packages/base-os-tools/config.sh
+++ b/packages/base-os-tools/config.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/base-os-tools.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+function build() {
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
Adds the base-os-tools package.
Currently this package doesn't contain anything.

In the future it will be used as a dependency of other packages in the Delphix Appliance and provide functionality such as what is needed for https://jira.delphix.com/browse/DLPX-65226.

## Testing
 - make check
 - linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/262
 - ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1793