### PR TITLE
Store Build Info by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,20 @@ should only be overridden when not fetching the package source from git.
 The `build()` hook is mandatory. It is responsible for building the package and
 storing the build products into `packages/<package>/tmp/artifacts/`.
 
+#### Store Build Info
+
+The `store_build_info()` hook is optional. It is called right after the
+build hook. It is responsible of creating the `<WORKDIR>/build_info` file that
+contains information about the source of the code used to build the package.
+
+A default hook is provided in `default-package-config.sh` and will
+be used if it is not overriden. If the package comes from a git repository,
+the default hook will store the git hash, branch and repository of the
+package's source.
+
+`build_info` files for each package are consumed by the
+[metapackage](./build-info-pkg) when running [buildlist.sh](#buildlistsh).
+
 #### Checkstyle
 
 The `checkstyle()` hook is optional. It is called before building the package if
@@ -459,11 +473,7 @@ The following files are used as status indicators in `WORKDIR`:
 * **repo-updated**: created if **repo-HEAD** has updates that should be pushed,
   following a merge.
 
-Finally, when building a package, build info should be stored in the
-**build_info** file under `WORKDIR`. To store some default git info,
-`store_git_info()` can be called. **build_info** files for each package are
-consumed by the [metapackage](./build-info-pkg) when running
-[buildlist.sh](#buildlistsh).
+* **build_info**: created by the `store_build_info()` package hook.
 
 ## Adding new packages
 

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -237,6 +237,9 @@ logmust cd "$WORKDIR"
 stage build
 logmust rm "$WORKDIR/building"
 
+logmust cd "$WORKDIR"
+stage store_build_info
+
 echo_success "Package $PACKAGE has been built successfully."
 echo "Build products are in $WORKDIR/artifacts"
 echo ""

--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -26,3 +26,11 @@
 function fetch() {
 	logmust fetch_repo_from_git
 }
+
+function store_build_info() {
+	if [[ -d "$WORKDIR/repo/.git" ]]; then
+		logmust store_git_info
+	else
+		echo "No build info available" >"$WORKDIR/build_info"
+	fi
+}

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -57,3 +57,7 @@ function build() {
 	#
 	logmust install_pkgs "$WORKDIR/artifacts/"*.deb
 }
+
+function store_build_info() {
+	echo "Tar file: $tarfile" >"$WORKDIR/build_info"
+}

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -52,7 +52,6 @@ function build() {
 	PACKAGE_VERSION=$(dpkg-parsechangelog | sed -rne 's,^Version: (.*),\1,p')
 
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 
 	# Install libbcc which is required to build bpftrace
 	logmust install_pkgs "$WORKDIR/artifacts"/libbcc_*.deb

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -69,7 +69,6 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -30,6 +30,4 @@ function build() {
 	logmust cd "$WORKDIR/repo/challenge_response"
 	logmust make package
 	logmust mv ./x86_64/*.deb "$WORKDIR/artifacts/"
-
-	logmust store_git_info
 }

--- a/packages/cloud-init/config.sh
+++ b/packages/cloud-init/config.sh
@@ -36,7 +36,6 @@ function build() {
 		logmust eval PACKAGE_VERSION="$(python3 tools/read-version)"
 	fi
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -48,6 +48,4 @@ function build() {
 
 	logmust cd "$WORKDIR/repo"
 	logmust mv ./*.deb "$WORKDIR/artifacts/"
-
-	logmust store_git_info
 }

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -29,5 +29,4 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -24,6 +24,4 @@ function build() {
 	logmust make package
 	logmust make package-dev
 	logmust mv ./out/*.deb "$WORKDIR/artifacts/"
-
-	logmust store_git_info
 }

--- a/packages/delphix-kernel/config.sh
+++ b/packages/delphix-kernel/config.sh
@@ -38,5 +38,4 @@ function build() {
 		logmust ./configure.sh
 		logmust dpkg_buildpackage_default
 	done
-	logmust store_git_info
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -32,5 +32,4 @@ function build() {
 		VERSION="$PACKAGE_VERSION-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*.deb "$WORKDIR/artifacts/"
-	logmust store_git_info
 }

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -35,5 +35,4 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -42,5 +42,4 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }

--- a/packages/java8/config.sh
+++ b/packages/java8/config.sh
@@ -51,3 +51,7 @@ function build() {
 	#
 	logmust install_pkgs "$WORKDIR/artifacts/"*.deb
 }
+
+function store_build_info() {
+	echo "Tar file: $tarfile" >"$WORKDIR/build_info"
+}

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -36,5 +36,4 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }

--- a/packages/make-jpkg/config.sh
+++ b/packages/make-jpkg/config.sh
@@ -32,7 +32,6 @@ function build() {
 	fi
 
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 
 	# java-package supporting adoptopenjdk needs to be installed to
 	# create jdk debian package from jdk tarball when building adoptopenjdk

--- a/packages/python-rtslib-fb/config.sh
+++ b/packages/python-rtslib-fb/config.sh
@@ -31,7 +31,6 @@ function build() {
 		logmust eval PACKAGE_VERSION="$(./setup.py --version)"
 	fi
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/packages/targetcli-fb/config.sh
+++ b/packages/targetcli-fb/config.sh
@@ -32,7 +32,6 @@ function build() {
 			sed 's/fb//')"
 	fi
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -47,7 +47,6 @@ function build() {
 	logmust bin/omnibus build td-agent3
 	# copy to artifacts
 	logmust cp "$WORKDIR"/repo/pkg/*.deb "$WORKDIR/artifacts/"
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -162,8 +162,6 @@ function build() {
 	done
 	logmust cd "$WORKDIR"
 	logmust mv "all-packages/"*.deb "artifacts/"
-
-	logmust store_git_info
 }
 
 function update_upstream() {

--- a/template/config.sh
+++ b/template/config.sh
@@ -73,7 +73,6 @@ function build() {
 	# Those are the default functions to build the package:
 	#
 	logmust dpkg_buildpackage_default
-	logmust store_git_info
 }
 
 #


### PR DESCRIPTION
With this code in place, we can simplify the `config.sh` file for most packages by removing the call to `store_git_info()`. This will also make sure that whenever we build a package from git, the build info is always stored as we forgot to add it for a few packages.

## Testing:
- make check
- verify contents of new global build-info file
- linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/261/
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1792