### PR TITLE
Use "libkdumpfile" when building "drgn"

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -10,6 +10,7 @@ bcc
 java8
 make-jpkg
 adoptopenjdk
+libkdumpfile
 
 delphix-sso-app
 bpftrace
@@ -20,7 +21,6 @@ crypt-blowfish
 delphix-platform
 drgn
 gdb-python
-libkdumpfile
 python-rtslib-fb
 targetcli-fb
 ptools

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -36,4 +36,7 @@ function prepare() {
 
 function build() {
 	logmust dpkg_buildpackage_default
+
+	# Install libkdumpfile, it's needed to build drgn
+	logmust install_pkgs "$WORKDIR/artifacts"/*.deb
 }


### PR DESCRIPTION
We've integrated changes to "drgn" such that it will automatically
detect "libkdumpfile" if it's installed, and enable support for kernel
core dump files when it's detected. To ensure "drgn" is built with this
functionality enabled, we need to install the "libkdumpfile" package
after building it, and prior to building the "drgn" package.