### PR TITLE
DLPX-64156 crashdump should only include ZFS metadata

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -21,6 +21,7 @@ crypt-blowfish
 delphix-platform
 drgn
 gdb-python
+makedumpfile
 nfs-utils
 python-rtslib-fb
 sdb

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/makedumpfile.git"
+# Note: we get the package version programatically in our build() hook
+
+DEFAULT_PACKAGE_GIT_BRANCH="master"
+
+UPSTREAM_SOURCE_PACKAGE="makedumpfile"
+
+function prepare() {
+	logmust install_source_package_build_deps
+}
+
+function build() {
+	logmust cd "$WORKDIR/repo"
+	if [[ -z "$PACKAGE_VERSION" ]]; then
+		logmust eval PACKAGE_VERSION="$(grep '^VERSION=' Makefile | cut -d "=" -f 2)"
+	fi
+	logmust dpkg_buildpackage_default
+	# we only need makedumpfile package
+	logmust rm -f "$WORKDIR/artifacts/"kdump-tools_*_amd64.deb
+}
+
+function update_upstream() {
+	logmust update_upstream_from_source_package
+}


### PR DESCRIPTION
**Description**

Add `makedumpfile` package

We need a modified `makedumpfile(8)` command that can filter ZFS file data pages from the kernel crash dump file. This package is one part of the necessary changes to bring about ZFS file data page filtering.

**Related Changes**
The makedumpfile patch is at https://github.com/delphix/makedumpfile/commit/9d7983e44b which adds the `'--private-page-filter'` option

A corresponding ZFS kernel module changes landed in: 
 https://github.com/zfsonlinux/zfs/commit/28c91ab66d

A follow up change, once this patch has landed, is to change the /etc/default/kdump-tools configuration file to start passing the `--private-page-filter` option to makedumpfile.

**Testing**
Appliance build pre-push (using linux-pkg userland build artifacts):
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2061/

Manually tested using `git-linux-pkg build` to install makedumpfile on a target host and confirmed that it can filter ZFS pages  with the '--private-page-filter' option. 