### PR TITLE
Do not set DEFAULT_PACKAGE_GIT_BRANCH to master

### DIFF
--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/libkdumpfile.git"
-DEFAULT_PACKAGE_GIT_BRANCH="master"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -19,8 +19,6 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/makedumpfile.git"
 # Note: we get the package version programatically in our build() hook
 
-DEFAULT_PACKAGE_GIT_BRANCH="master"
-
 UPSTREAM_SOURCE_PACKAGE="makedumpfile"
 
 function prepare() {


### PR DESCRIPTION
We should build packages according to the DEFAULT_BRANCH branch
which is passed by Jenkins and is the same for linux-pkg and all
its packages.

If we branch out to `6.0/stage`, then we'd have to manually update `DEFAULT_PACKAGE_GIT_BRANCH` to `6.0/stage`. Instead of doing that, we should just leave `DEFAULT_PACKAGE_GIT_BRANCH` unset.

## Testing
- linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/307/