### PR TITLE
Fetch package as first step

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -199,9 +199,6 @@ if $do_initialize; then
 fi
 
 logmust cd "$WORKDIR"
-stage prepare
-
-logmust cd "$WORKDIR"
 stage fetch
 
 if $DO_UPDATE_PACKAGE; then
@@ -227,6 +224,9 @@ if $DO_UPDATE_PACKAGE; then
 		exit 0
 	fi
 fi
+
+logmust cd "$WORKDIR"
+stage prepare
 
 logmust touch "$WORKDIR/building"
 if $do_checkstyle; then


### PR DESCRIPTION
We want to fetch the package as the first step since
this will allow us 2 things:

  1. If we are running update and we are in-sync with
     upstream then no need to run the prepare stage.
  2. In the prepare stage, we can read the package's
     control file to install build dependencies

## Motivation

This is part of a series of small series of linux-pkg improvements in preparation for the release cutoff that will make the build simpler and more reliable.

## Testing

- build userland list: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/317/
- build kernel list: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/77/
- update on userland list: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/3/