### PR TITLE
revert using control file to build delphix-kernel

### DIFF
--- a/packages/delphix-kernel/config.sh
+++ b/packages/delphix-kernel/config.sh
@@ -20,7 +20,9 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-kernel.git"
 DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function prepare() {
-	logmust install_build_deps_from_control_file
+	logmust install_pkgs \
+		debhelper \
+		devscripts
 }
 
 function build() {


### PR DESCRIPTION
https://github.com/delphix/linux-pkg/pull/54 broke the build of the kernel list.

The `delphix-kernel` package doesn't have a `control` file, but uses a template `control.in` file so it is not eligible to use the new functionality.

I should have tested building both lists in that change.

## Testing

linux-pkg-build kernel list:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/78