### PR TITLE
Use a pre-built package for td-agent

### DIFF
--- a/package-lists/build/td-agent.pkgs
+++ b/package-lists/build/td-agent.pkgs
@@ -1,0 +1,8 @@
+#
+# Since building td-agent is currently quite unreliable as it depends on
+# lots of external dependencies that are out of our control, we do not want
+# to fail our build when some of those dependencies are broken. As such,
+# we build td-agent in a separate build list and include a pre-built package
+# in the main list.
+#
+td-agent

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -27,4 +27,4 @@ python-rtslib-fb
 sdb
 targetcli-fb
 ptools
-td-agent
+td-agent-prebuilt

--- a/packages/td-agent-prebuilt/config.sh
+++ b/packages/td-agent-prebuilt/config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL=none
+package="td-agent_3.5.0-delphix-2019.09.18.20_amd64.deb"
+
+function fetch() {
+	logmust cd "$WORKDIR/artifacts"
+
+	local url="http://artifactory.delphix.com/artifactory"
+
+	logmust wget -nv "$url/linux-pkg/td-agent/$package" -O "$package"
+}
+
+function build() {
+	return
+	# Nothing to do. See the td-agent package config for the actual build.
+}


### PR DESCRIPTION
Do not re-build td-agent on every userland packages build.

The main issue with the td-agent is that it consumes a lot of external dependencies on which we do not have control. While some of those dependencies could be mirrored, for others it's quite complex. Because of a recent breakage in td-agent's dependencies, where a package was pulled from the Ruby Gems public repository, td-agent cannot be currently built. Until we figure either how to make td-agent's build more reliable or not have failures affect the rest of the build, we will be using a pre-built td-agent package deployed into artifactory.

This is a temporary change to unblock the build, we may iterate on it further in the upcoming days/weeks.

## Testing
- linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/340/ (pass)
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2216/ (pass)