### PR TITLE
Fix drgn build failures caused by building elfutil from scratch

### DIFF
--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -26,13 +26,21 @@ function prepare() {
 	logmust install_pkgs \
 		autoconf \
 		automake \
+		bison \
+		flex \
+		gawk \
 		git \
+		gcc \
+		libbz2-dev \
 		libdw-dev \
 		libelf-dev \
+		liblzma-dev \
 		libtool \
+		make \
 		pkg-config \
 		python3-distutils \
-		python3.6-dev
+		python3.6-dev \
+		zlib1g-dev
 }
 
 function build() {


### PR DESCRIPTION
Recently drgn started builting the latest elfutils as part of its
building process. Ensure that the prerequisites for that library
are installed on the system before attempting to build drgn.

For reference the commits that caused this are the following:
1cedca8ff4e39207aa5b0a1a34793dcbdb1f025f
6a13d74c0c45881c7e26b3c16a2d76413c740641

Side-note:
From my discussion with Pavel, it seems like it would be better
to add all the dependencies of the debian config in the `drgn`
repo and change the `prepare()` function in `linux-pkg` to do
`install_build_deps_from_control_file()`. This way we don't have
to change `linux-pkg` every time some dependency changes in
`drgn` (plus it would make our repo more self-contained for
folks outside Delphix who want to create a debian package out
of it). The reason why we decided to submit this first though
before the refactoring was to avoid any potential flag days.

# Testing Links:
Userland pkg build job - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/348/

ab-pre-push - http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2249/flowGraphTable/ (pending)