### PR TITLE
Output debug symbol (.ddeb) packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,9 +785,9 @@ More instructions available
 ## Versions and Branches
 
 The framework is designed in a way to allow easy integration with the Delphix
-release process. The idea is that both the package build artifacts (`.debs`)
-and package source code should be available for each Delphix release. This
-should hold for both in-house and third-party packages.
+release process. The idea is that both the package build artifacts (`.deb`s
+and `.ddeb`s) and package source code should be available for each Delphix
+release. This should hold for both in-house and third-party packages.
 
 Regarding the build artifacts, those should be taken care of by the existing
 Delphix build artifacts storage policy, available

--- a/build-info-pkg/build-package.sh
+++ b/build-info-pkg/build-package.sh
@@ -84,6 +84,6 @@ export PACKAGE_REVISION=${DEFAULT_REVISION:-0}
 logmust set_changelog "$package_name"
 logmust dpkg-buildpackage -uc -us -b
 logmust mkdir -p artifacts
-logmust mv ../"$package_name"*.deb artifacts/
+logmust mv ../"$package_name"*deb artifacts/
 logmust rm -f ../"$package_name"*.buildinfo ../"$package_name"*.changes
 logmust cp "$INFO_FILE" artifacts/build-info

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -648,7 +648,7 @@ function dpkg_buildpackage_default() {
 	logmust set_changelog
 	logmust dpkg-buildpackage -b -us -uc
 	logmust cd "$WORKDIR/"
-	logmust mv ./*.deb artifacts/
+	logmust mv ./*deb artifacts/
 }
 
 #

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -21,7 +21,7 @@ tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u212b04.tar.gz"
 jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 
 function prepare() {
-	if ! ls "$TOP/packages/make-jpkg/tmp/artifacts/"*.deb >/dev/null 2>&1; then
+	if ! ls "$TOP/packages/make-jpkg/tmp/artifacts/"*deb >/dev/null 2>&1; then
 		echo_bold "custom java-package not installed. Building package 'make-jpkg' first."
 		logmust "$TOP/buildpkg.sh" make-jpkg
 	fi
@@ -40,7 +40,7 @@ function build() {
 
 	logmust env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
 
-	logmust mv ./*.deb "$WORKDIR/artifacts/"
+	logmust mv ./*deb "$WORKDIR/artifacts/"
 	#
 	# Store the install path of the JDK in a file so that the users of this
 	# Java package know where to look. This is especially useful for

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -29,5 +29,5 @@ function prepare() {
 function build() {
 	logmust cd "$WORKDIR/repo/challenge_response"
 	logmust make package
-	logmust mv ./x86_64/*.deb "$WORKDIR/artifacts/"
+	logmust mv ./x86_64/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -47,5 +47,5 @@ function build() {
 	logmust dpkg-buildpackage -b -us -uc
 
 	logmust cd "$WORKDIR/repo"
-	logmust mv ./*.deb "$WORKDIR/artifacts/"
+	logmust mv ./*deb "$WORKDIR/artifacts/"
 }

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -23,5 +23,5 @@ function build() {
 	logmust cd "$WORKDIR/repo/crypt_blowfish"
 	logmust make package
 	logmust make package-dev
-	logmust mv ./out/*.deb "$WORKDIR/artifacts/"
+	logmust mv ./out/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -31,5 +31,5 @@ function build() {
 	logmust ./scripts/docker-run.sh make packages \
 		VERSION="$PACKAGE_VERSION-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
-	logmust mv artifacts/*.deb "$WORKDIR/artifacts/"
+	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-sso-app/config.sh
+++ b/packages/delphix-sso-app/config.sh
@@ -32,5 +32,5 @@ function build() {
 	java_home=$(cat "$JDK_PATH_FILE")
 	logmust cd "$WORKDIR/repo"
 	logmust sudo ./gradlew "-Dorg.gradle.java.home=$java_home" distDeb
-	logmust sudo mv ./build/distributions/*.deb "$WORKDIR/artifacts/"
+	logmust sudo mv ./build/distributions/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/java8/config.sh
+++ b/packages/java8/config.sh
@@ -34,7 +34,7 @@ function fetch() {
 function build() {
 	logmust cd "$WORKDIR"
 	logmust env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$tarfile" <<<y
-	logmust mv ./*.deb "$WORKDIR/artifacts/"
+	logmust mv ./*deb "$WORKDIR/artifacts/"
 	#
 	# Store the install path of the JDK in a file so that the users of this
 	# Java package know where to look. This is especially useful for

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -46,7 +46,7 @@ function build() {
 	# now kick off the build
 	logmust bin/omnibus build td-agent3
 	# copy to artifacts
-	logmust cp "$WORKDIR"/repo/pkg/*.deb "$WORKDIR/artifacts/"
+	logmust cp "$WORKDIR"/repo/pkg/*deb "$WORKDIR/artifacts/"
 }
 
 function update_upstream() {


### PR DESCRIPTION
linux-pkg already creates `.ddeb` packages where appropriate, we just need to copy them to the `artifacts/` directory so that they get uploaded with the rest of the packages by Jenkins at the end of a build.

This mostly just involves changing `mv ./*.debs ...` to `mv ./*debs ...` so that the glob will match `.ddeb` packages as well. Note that I've made this change in a few places where it isn't strictly necessary (in packages that don't produce a corresponding `ddeb` package), because it doesn't hurt anything and it helps to establish a pattern to be followed in the future.