### PR TITLE
LB-229 [Backport of LB-215 to 6.0/release] Want linux-pkg-build to us…

### DIFF
--- a/branch.config
+++ b/branch.config
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2019 by Delphix. All rights reserved.
+#
+
+#
+# The "BRANCH" parameter tracks the upstream branch of linux-pkg. It is
+# used to determine which branch of the linux package mirror will be used for
+# the build if DEFAULT_GIT_BRANCH is not set. DEFAULT_GIT_BRANCH is set when
+# linux pkg is built by the linux-pkg-build Jenkins jobs. The
+# DEFAULT_GIT_BRANCH parameter should be updated by the release lead on
+# branching.
+#
+
+DEFAULT_GIT_BRANCH="6.0/release"

--- a/buildlist.sh
+++ b/buildlist.sh
@@ -52,11 +52,6 @@ logmust mkdir artifacts
 # default used if the revision is not set explicitly anywhere else.
 #
 export DEFAULT_REVISION="${DEFAULT_REVISION:-$(default_revision)}"
-#
-# Default branch to checkout when fetching source code for packages. Note that
-# this can be overriden by per-package settings.
-#
-export DEFAULT_GIT_BRANCH="${DEFAULT_GIT_BRANCH:-master}"
 
 #
 # A list of target platform or versions to build modules for can be passed in

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -22,6 +22,30 @@ export DEBIAN_FRONTEND=noninteractive
 # TODO: allow updating upstream for other branches than master
 export REPO_UPSTREAM_BRANCH="upstreams/master"
 
+#
+# Determine DEFAULT_GIT_BRANCH. If it is unset, default to the branch set in
+# branch.config.
+#
+if [[ -z "$DEFAULT_GIT_BRANCH" ]]; then
+	echo "DEFAULT_GIT_BRANCH is not set."
+	if ! source "$TOP/branch.config" 2>/dev/null; then
+		echo "No branch.config file found in repo root."
+		exit 1
+	fi
+
+	if [[ -z "$DEFAULT_GIT_BRANCH" ]]; then
+		echo "$DEFAULT_GIT_BRANCH parameter was not sourced from " \
+			"branch.config. Ensure branch.config is properly formatted with " \
+			"e.g. DEFAULT_GIT_BRANCH=\"<upstream-product-branch>\""
+		exit 1
+	fi
+
+	echo "Defaulting DEFAULT_GIT_BRANCH to branch $DEFAULT_GIT_BRANCH set in" \
+		"branch.config."
+
+	export DEFAULT_GIT_BRANCH
+fi
+
 # shellcheck disable=SC2086
 function enable_colors() {
 	[[ -t 1 ]] && flags="" || flags="-T xterm"


### PR DESCRIPTION
Backport of commit 9439ed9da73ca4e5215c97bdd04f4911d0580c81 on master, allowing linux-pkg-build to use the package mirror for 6.0/release builds

testing build (manually removed setting DEFAULT_GIT_BRANCH via jenkins)
http://collins.d.delphix.com:35379/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/release/job/kernel/job/pre-push/3/consoleFull