### PR TITLE
Add performance-diagnostics package

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -26,5 +26,6 @@ nfs-utils
 python-rtslib-fb
 sdb
 targetcli-fb
+performance-diagnostics
 ptools
 td-agent-prebuilt

--- a/packages/performance-diagnostics/config.sh
+++ b/packages/performance-diagnostics/config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+#
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/performance-diagnostics.git"
+DEFAULT_PACKAGE_VERSION="1.0.0"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
Create performance-diagnostics package and add it to `userland` list. Note that this shouldn't be merged until `DEFAULT_PACKAGE_GIT_URL` has been updated, which can be done after the performance-diagnostics code is pushed to the official repo.