### PR TITLE
DLPX-67499 Use the HWE kernel for the generic platform on Ubuntu 18.04 (Part 2 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ There's a set of environment variables that can be set to modify the operation
 of some of the scripts defined above.
 
 * **DISABLE_SYSTEM_CHECK**: Set to "true" to disable the check that makes sure
-  we are running on an Ubuntu Bionic (18.04) system in AWS. Affects all scripts.
+  we are running on the appropriate Ubuntu distribution in AWS.
+  Affects all scripts.
 
 * **DRY_RUN**: Set to "true" to prevent `updatelist.sh` from updating production
   package repositories. `updatelist.sh` will invoke `push-updates.sh` with `-n`.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -22,6 +22,8 @@ export DEBIAN_FRONTEND=noninteractive
 # TODO: allow updating upstream for other branches than master
 export REPO_UPSTREAM_BRANCH="upstreams/master"
 
+export UBUNTU_DISTRIBUTION="bionic"
+
 #
 # Determine DEFAULT_GIT_BRANCH. If it is unset, default to the branch set in
 # branch.config.
@@ -103,9 +105,9 @@ function logmust() {
 }
 
 #
-# Check that we are running on an Ubuntu Bionic system in AWS.
-# This is not a strict requirement for the build to work but rather a
-# safety measure to prevent developers from accidentally running the
+# Check that we are running in AWS on an Ubuntu system of the appropriate
+# distribution. This is not a strict requirement for the build to work but
+# rather a safety measure to prevent developers from accidentally running the
 # scripts on their work system and changing its configuration.
 #
 function check_running_system() {
@@ -115,8 +117,8 @@ function check_running_system() {
 	fi
 
 	if ! (command -v lsb_release >/dev/null &&
-		[[ $(lsb_release -cs) == "bionic" ]]); then
-		die "Script can only be ran on an ubuntu-bionic system."
+		[[ $(lsb_release -cs) == "$UBUNTU_DISTRIBUTION" ]]); then
+		die "Script can only be ran on an ubuntu-${UBUNTU_DISTRIBUTION} system."
 	fi
 
 	if ! curl "http://169.254.169.254/latest/meta-datas" \
@@ -695,6 +697,7 @@ function store_git_info() {
 #
 function get_kernel_for_platform() {
 	local platform="$1"
+	local package
 
 	#
 	# For each supported platform, Ubuntu provides a 'linux-image-PLATFORM'
@@ -705,10 +708,21 @@ function get_kernel_for_platform() {
 	# for kernel version '4.15.0-1027-aws'. We use this depenency to figure
 	# out the default kernel version for a given platform.
 	#
+	# The "generic" platform is a special case, since we want to use the
+	# hwe kernel image instead of the regular generic image.
+	#
 	# Note that while the default kernel is usually also the latest
 	# available, it is not always the case.
 	#
-	if [[ "$(apt-cache show --no-all-versions "linux-image-${platform}" \
+
+	if [[ "$platform" == generic ]] &&
+		[[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
+		package=linux-image-generic-hwe-18.04
+	else
+		package="linux-image-${platform}"
+	fi
+
+	if [[ "$(apt-cache show --no-all-versions "$package" \
 		2>/dev/null | grep Depends)" =~ linux-image-([^,]*-${platform}) ]]; then
 		_RET=${BASH_REMATCH[1]}
 		return 0

--- a/setup.sh
+++ b/setup.sh
@@ -44,17 +44,17 @@ configure_apt_sources() {
 	)
 
 	sudo bash -c "cat <<-EOF >/etc/apt/sources.list
-deb ${package_mirror_url} bionic main restricted universe multiverse
-deb-src ${package_mirror_url} bionic main restricted universe multiverse
+deb ${package_mirror_url} ${UBUNTU_DISTRIBUTION} main restricted universe multiverse
+deb-src ${package_mirror_url} ${UBUNTU_DISTRIBUTION} main restricted universe multiverse
 
-deb ${package_mirror_url} bionic-updates main restricted universe multiverse
-deb-src ${package_mirror_url} bionic-updates main restricted universe multiverse
+deb ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-updates main restricted universe multiverse
+deb-src ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-updates main restricted universe multiverse
 
-deb ${package_mirror_url} bionic-security main restricted universe multiverse
-deb-src ${package_mirror_url} bionic-security main restricted universe multiverse
+deb ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-security main restricted universe multiverse
+deb-src ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-security main restricted universe multiverse
 
-deb ${package_mirror_url} bionic-backports main restricted universe multiverse
-deb-src ${package_mirror_url} bionic-backports main restricted universe multiverse
+deb ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-backports main restricted universe multiverse
+deb-src ${package_mirror_url} ${UBUNTU_DISTRIBUTION}-backports main restricted universe multiverse
 EOF" || die "/etc/apt/sources.list could not be updated"
 }
 


### PR DESCRIPTION
This is part 2 of 2 for DLPX-67499.
Part 1 of 2 is here: https://github.com/delphix/delphix-kernel/pull/8

We change the logic to determine the latest kernel version for the "generic" kernel flavour to look at the package `linux-generic-hwe-18.04` instead of `linux-image-generic`.

As an additional change, we add a new variable for the Ubuntu distribution we are building for. This will make it easier for us to switch to a new Ubuntu distribution later.

## Flag-day
Both parts of this change must be pushed at the same time, otherwise appliance-build will be broken.

## Testing
linux-pkg-build [kernel]: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/113/
ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2538/