### PR TITLE
add latest crash-util

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -16,6 +16,7 @@ delphix-sso-app
 bpftrace
 challenge-response
 cloud-init
+crash
 crash-python
 crypt-blowfish
 delphix-platform

--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -13,6 +13,7 @@
 
 bpftrace
 cloud-init
+crash
 drgn
 nfs-utils
 python-rtslib-fb

--- a/packages/crash/config.sh
+++ b/packages/crash/config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/crash.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+UPSTREAM_GIT_URL="https://github.com/crash-utility/crash.git"
+UPSTREAM_GIT_BRANCH="master"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
See PR: https://github.com/delphix/crash/pull/1
Testing on latest 5.0:
```
delphix@ip-10-110-241-113:~$ sudo crash /usr/lib/debug/boot/vmlinux-4.15.0-1056-aws

crash 7.2.7++
Copyright (C) 2002-2019  Red Hat, Inc.
Copyright (C) 2004, 2005, 2006, 2010  IBM Corporation
Copyright (C) 1999-2006  Hewlett-Packard Co
Copyright (C) 2005, 2006, 2011, 2012  Fujitsu Limited
Copyright (C) 2006, 2007  VA Linux Systems Japan K.K.
Copyright (C) 2005, 2011  NEC Corporation
Copyright (C) 1999, 2002, 2007  Silicon Graphics, Inc.
Copyright (C) 1999, 2000, 2001, 2002  Mission Critical Linux, Inc.
This program is free software, covered by the GNU General Public License,
and you are welcome to change it and/or distribute copies of it under
certain conditions.  Enter "help copying" to see the conditions.
This program has absolutely no warranty.  Enter "help warranty" for details.

GNU gdb (GDB) 7.6
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-unknown-linux-gnu"...

WARNING: kernel relocated [938MB]: patching 94997 gdb minimal_symbol values

      KERNEL: /usr/lib/debug/boot/vmlinux-4.15.0-1056-aws
    DUMPFILE: /proc/kcore
        CPUS: 2
        DATE: Tue Dec 10 18:53:33 2019
      UPTIME: 00:04:10
LOAD AVERAGE: 3.46, 1.17, 0.42
       TASKS: 320
    NODENAME: ip-10-110-241-113
     RELEASE: 4.15.0-1056-aws
     VERSION: #58-Ubuntu SMP Tue Nov 26 15:14:34 UTC 2019
     MACHINE: x86_64  (2400 Mhz)
      MEMORY: 8 GB
         PID: 5414
     COMMAND: "crash"
        TASK: ffff929bb43496c0  [THREAD_INFO: ffff929bb43496c0]
         CPU: 0
       STATE: TASK_RUNNING (ACTIVE)

crash>
crash> bt
PID: 5414   TASK: ffff929bb43496c0  CPU: 0   COMMAND: "crash"
(active)
crash> exit
```