### PR TITLE
Add "-r" option to "updatelist.sh" script

### DIFF
--- a/jenkins-updatelist.sh
+++ b/jenkins-updatelist.sh
@@ -46,6 +46,12 @@ else
 	dry_run='-n'
 fi
 
+if [[ "$GIT_RELEASE" == "true" ]]; then
+	release='-r'
+else
+	release=''
+fi
+
 logmust cd "$TOP"
 logmust ./setup.sh
-logmust ./updatelist.sh $dry_run "$UPDATE_LIST"
+logmust ./updatelist.sh $dry_run $release "$UPDATE_LIST"


### PR DESCRIPTION
This change adds the "-r" option to the "updatelist.sh" script to enable
us to update only the packages that pull from source packages. This is
useful for updating release branches with important security updates
that may come from upstream source packages.