### PR TITLE
Revert "temporarily disable auto-update of crash package"

### DIFF
--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -13,7 +13,7 @@
 
 bpftrace
 cloud-init
-#crash
+crash
 drgn
 nfs-utils
 python-rtslib-fb


### PR DESCRIPTION
This reverts commit e9e5a3802342f83fd8f4b34f1c52506daa80c471.

Re-enable auto-update of the crash package, now that the appropriate changes were done to the `delphix/crash` repository.

## Testing
linux-pkg update job: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/4/consoleFull