### PR TITLE
DLPX-67915 Add oracle-specific kernel

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2019 Delphix
+# Copyright 2018, 2020 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -750,7 +750,7 @@ function determine_target_kernels() {
 		return 0
 	fi
 
-	local supported_platforms="generic aws gcp azure kvm"
+	local supported_platforms="generic aws gcp azure oracle"
 	local platform
 
 	if [[ -z "$TARGET_PLATFORMS" ]]; then


### PR DESCRIPTION
This change introduces an oracle-specific kernel and remove the kvm-specific kernel which is no longer used. The kvm-specific kernel is no longer used by any of our platforms and the kvm platform now relies on the generic kernel (see https://github.com/delphix/delphix-platform/pull/151)