### PR TITLE
DLPX-68435 crash dump fails on 5.3 kernel

### DIFF
--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -15,6 +15,7 @@ bpftrace
 cloud-init
 crash
 drgn
+makedumpfile
 nfs-utils
 python-rtslib-fb
 targetcli-fb

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -28,11 +28,9 @@ function prepare() {
 function build() {
 	logmust cd "$WORKDIR/repo"
 	if [[ -z "$PACKAGE_VERSION" ]]; then
-		logmust eval PACKAGE_VERSION="$(grep '^VERSION=' Makefile | cut -d "=" -f 2)"
+		logmust eval PACKAGE_VERSION="1:$(grep '^VERSION=' Makefile | cut -d "=" -f 2)"
 	fi
 	logmust dpkg_buildpackage_default
-	# we only need makedumpfile package
-	logmust rm -f "$WORKDIR/artifacts/"kdump-tools_*_amd64.deb
 }
 
 function update_upstream() {


### PR DESCRIPTION
Enable auto-update for the makedumpfile package and do not
remove kdump-tools to keep both packages built from the same source.
Also prepended `1:` to version numbering to match Ubuntu's versioning schema (note that without this, the build is broken as `kexec-tools` has `Breaks: kdump-tools (<< 1:1.5.9-6)`)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Testing
- ab-pre-push (linux-pkg only): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2886/
- ab-pre-push (including merging latest makedumpfile): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2877/
- Tested auto-update works properly with `./updatelist -n userland`
- Also tested that merging latest makedumpfile fixes DLPX-68435. Will update that bug with more info once merge job updates makedumpfile.