### PR TITLE
Deprecating DEFAULT_PACKAGE_GIT_BRANCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,11 +344,14 @@ Here is a list of variables that can be defined for a package:
   `https://` URL. One exception is if the source of the package being built
   isn't fetched from git. In this case, set this to "none".
 
-* **DEFAULT_PACKAGE_GIT_BRANCH**: (Optional) Default git branch to use when
+* **DEFAULT_PACKAGE_GIT_BRANCH**: (DEPRECATED) Default git branch to use when
   fetching from or pushing to `DEFAULT_PACKAGE_GIT_URL`. This should be
   typically left unset. The branch to fetch the package from defaults
   to the value of the environment variable `DEFAULT_BRANCH`, which itself
   defaults to "master".
+  WARNING: do not set this parameter unless you know exactly what you are doing,
+  as our current versioning convention is to use DEFAULT_BRANCH for each
+  package. This parameter may be removed in the future.
 
 * **DEFAULT_PACKAGE_VERSION**: (Optional) The version of the package is set to
   this value when it is built. **Note:** If this field is not set, then you

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
-DEFAULT_PACKAGE_GIT_BRANCH="next"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
-DEFAULT_PACKAGE_GIT_BRANCH="master-suse-target"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {


### PR DESCRIPTION
Given our versioning model, where each package managed by linux-pkg
is tagged and branched according to releases, we should rely on the
DEFAULT_BRANCH parameter for fetching the source code for each package.

Setting DEFAULT_PACKAGE_GIT_BRANCH is dangerous for 2 reasons:

 - First because a release tag for that repository then becomes
   misleading, as it is not what is used to rebuild that repository
   for a particular release version.

 - Second, if changes are later pushed to that branch, then rebuilding
   the original release will pull those new changes.

For now, DEFAULT_PACKAGE_GIT_BRANCH is being deprecated rather than
removed. We will evaluate whether it still has value for testing
purposes or for projects such as SUV.

## Prerequisites
- Update `master` branch for `crash-python` to point to current `next` branch
- Update `master` branch for `gdb-python` to point to current `master-suse-target` branch

## Todo
- Update following branches of `gdb-python` to point to commit `f8aba183a57e5dea833953e243248aa5d79e12f7`: `master-suse-target`, `origin/6.0/stage`, `origin/6.0/release`, `origin/6.0/patch`, tag `release/6.0.0.0`. Those refs currently erroneously point to `fe7e91e7764d8db4a45c9d7b3dd55cb635f44f5e`, which is not what was used to build 6.0.0.0 or those other branches. (See `/lib/delphix-buildinfo/userland.info` on a 6.0.0.0 system for more info on what was used to build that system).
- Update `next` branch for `crash-python` to commit `644168b625801035635ca78671e4cb206d43c9b8`, which matches the `release/6.0.0.0` tag.
- Backport this change to `6.0/stage` and `6.0/patch`

## Testing
- linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/509/
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2915/
