### PR TITLE
[Backport to 6.0.1.0] Deprecating DEFAULT_PACKAGE_GIT_BRANCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,11 +344,14 @@ Here is a list of variables that can be defined for a package:
   `https://` URL. One exception is if the source of the package being built
   isn't fetched from git. In this case, set this to "none".
 
-* **DEFAULT_PACKAGE_GIT_BRANCH**: (Optional) Default git branch to use when
+* **DEFAULT_PACKAGE_GIT_BRANCH**: (DEPRECATED) Default git branch to use when
   fetching from or pushing to `DEFAULT_PACKAGE_GIT_URL`. This should be
   typically left unset. The branch to fetch the package from defaults
   to the value of the environment variable `DEFAULT_BRANCH`, which itself
   defaults to "master".
+  WARNING: do not set this parameter unless you know exactly what you are doing,
+  as our current versioning convention is to use DEFAULT_BRANCH for each
+  package. This parameter may be removed in the future.
 
 * **DEFAULT_PACKAGE_VERSION**: (Optional) The version of the package is set to
   this value when it is built. **Note:** If this field is not set, then you

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
-DEFAULT_PACKAGE_GIT_BRANCH="next"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
-DEFAULT_PACKAGE_GIT_BRANCH="master-suse-target"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {


### PR DESCRIPTION
Clean cherry-pick of https://github.com/delphix/linux-pkg/pull/80

## Testing
linux-pkg-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/stage/job/userland/job/pre-push/16/
