### PR TITLE
Backport: libkdumpfile: abstract out dependencies and sync with upstream

### DIFF
--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -14,6 +14,7 @@
 bpftrace
 cloud-init
 drgn
+libkdumpfile
 nfs-utils
 python-rtslib-fb
 targetcli-fb

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -16,21 +16,14 @@
 #
 
 # shellcheck disable=SC2034
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/libkdumpfile.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
+UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
+UPSTREAM_GIT_BRANCH="master"
+
 function prepare() {
-	logmust install_pkgs \
-		autoconf \
-		automake \
-		git \
-		liblzo2-dev \
-		libsnappy1v5 \
-		libtool \
-		pkg-config \
-		python3-distutils \
-		python3.6-dev \
-		zlib1g-dev
+	logmust install_build_deps_from_control_file
 }
 
 function build() {
@@ -38,4 +31,8 @@ function build() {
 
 	# Install libkdumpfile, it's needed to build drgn
 	logmust install_pkgs "$WORKDIR/artifacts"/*.deb
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
 }


### PR DESCRIPTION
userland pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/555/

Used the S3 link from the above and run the following ab-pre-push:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3167/

Even though the above is still pending a new image was created for ESX where I was able to ensure that the new libkdumpfile bits are there and usable for kdumps by `sdb` and `drgn`.