### PR TITLE
Add grub2 package to the Delphix build process

### DIFF
--- a/package-lists/build/kernel.pkgs
+++ b/package-lists/build/kernel.pkgs
@@ -3,6 +3,11 @@
 # kernel versions.
 #
 
+# Note: The following packages should be built first because other packages
+# depend on them being built.
+#  - zfs is required by grub2
+zfs
+
 connstat
 delphix-kernel
-zfs
+grub2

--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -21,3 +21,4 @@ nfs-utils
 python-rtslib-fb
 targetcli-fb
 td-agent
+grub2

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -17,9 +17,7 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
-DEFAULT_PACKAGE_GIT_BRANCH="applied/ubuntu/bionic-updates"
 
-DEFAULT_PACKAGE_VERSION="2.02-2ubuntu8.15"
 UPSTREAM_SOURCE_PACKAGE=grub2
 
 #
@@ -39,6 +37,11 @@ function prepare() {
 # Build the package.
 #
 function build() {
+	logmust cd "$WORKDIR/repo"
+	if [[ -z "$PACKAGE_VERSION" ]]; then
+		logmust eval PACKAGE_VERSION="$(dpkg-parsechangelog -S Version | \
+		    awk -F'-' '{print $1}')"
+	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
+DEFAULT_PACKAGE_GIT_BRANCH="applied/ubuntu/bionic-updates"
+
+DEFAULT_PACKAGE_VERSION="2.02-2ubuntu8.15"
+UPSTREAM_SOURCE_PACKAGE=grub2
+
+#
+# Install build dependencies for the package.
+#
+function prepare() {
+	if ! dpkg-query --show libzfslinux-dev >/dev/null 2>&1; then
+		echo_bold "libzfs not installed. Building package 'zfs' first."
+		logmust "$TOP/buildpkg.sh" zfs
+	fi
+
+	logmust install_build_deps_from_control_file
+	return
+}
+
+#
+# Build the package.
+#
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+#
+# Hook to fetch upstream package changes and merge into our tree.
+#
+function update_upstream() {
+	logmust update_upstream_from_source_package
+	return
+}

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -18,7 +18,8 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
 
-UPSTREAM_SOURCE_PACKAGE=grub2
+UPSTREAM_GIT_URL=https://git.launchpad.net/ubuntu/+source/grub2
+UPSTREAM_GIT_BRANCH=applied/ubuntu/bionic-updates
 
 #
 # Install build dependencies for the package.
@@ -49,6 +50,6 @@ function build() {
 # Hook to fetch upstream package changes and merge into our tree.
 #
 function update_upstream() {
-	logmust update_upstream_from_source_package
+	logmust update_upstream_from_git
 	return
 }

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -162,6 +162,9 @@ function build() {
 	done
 	logmust cd "$WORKDIR"
 	logmust mv "all-packages/"*.deb "artifacts/"
+
+	# Install libzfs which is required to build grub
+	logmust install_pkgs "$WORKDIR/artifacts"/{libnvpair1linux,libuutil1linux,libzfs2linux,libzpool2linux,libzfslinux-dev}_*.deb
 }
 
 function update_upstream() {


### PR DESCRIPTION
This patch adds the grub2 package to the build process. This package recently had its own official repo added to the Delphix organization, and the patches to enable the recovery environment work there are still under review.

Tested via manual builds and installation of the produced packages, and also via automation:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/568/ and http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/150/ .  Note that the latter build failed; this is because our version of grub2 doesn't yet have the patch that fixes the build to work on ubuntu with a custom version of ZFS installed. I will update with a new run when that patch is integrated.