### PR TITLE
DLPX-69161 [Backport of DLPX-69137 6.0.2.0] walinuxagent package needs to be updated

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -29,3 +29,4 @@ targetcli-fb
 performance-diagnostics
 ptools
 td-agent-prebuilt
+walinuxagent

--- a/packages/walinuxagent/config.sh
+++ b/packages/walinuxagent/config.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/walinuxagent-ubuntu.git"
+UPSTREAM_GIT_URL="https://git.launchpad.net/ubuntu/+source/walinuxagent"
+UPSTREAM_GIT_BRANCH="ubuntu/bionic-updates"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function checkstyle() {
+	logmust cd "$WORKDIR/repo"
+	logmust make style-check
+}
+
+function build() {
+	logmust cd "$WORKDIR/repo"
+	PACKAGE_VERSION=$(
+		dpkg-parsechangelog -S Version | awk -F'-' '{print $1}'
+	)
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
Testing:

Userland build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/569/console

Kernel build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/153/console

Appliance build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3244/console