### PR TITLE
LB-290 Add query-packages script to linux-pkg

### DIFF
--- a/.github/scripts/verify-query-packages.sh
+++ b/.github/scripts/verify-query-packages.sh
@@ -1,0 +1,63 @@
+#!/bin/bash -ex
+# shellcheck disable=SC2012
+
+set -o pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Make sure a basic command doesn't print anything to stderr
+test -z "$(./query-packages.sh single -o name,git-url zfs 2>&1 >/dev/null)"
+
+# Expect: "zfs	https://github.com/delphix/zfs.git"
+read -r -a fields <<<"$(./query-packages.sh single -o name,git-url zfs 2>&1)"
+test ${#fields[@]} -eq 2
+test "${fields[0]}" == 'zfs'
+test "${fields[1]}" == 'https://github.com/delphix/zfs.git'
+
+# Expect: "https://github.com/delphix/zfs.git	zfs"
+read -r -a fields <<<"$(./query-packages.sh single -o git-url,name zfs 2>&1)"
+test ${#fields[@]} -eq 2
+test "${fields[0]}" == 'https://github.com/delphix/zfs.git'
+test "${fields[1]}" == 'zfs'
+
+# Expect: "zfs"
+read -r -a fields <<<"$(./query-packages.sh single zfs 2>&1)"
+test ${#fields[@]} -eq 1
+test "${fields[0]}" == 'zfs'
+
+# Expect: "https://github.com/delphix/zfs.git"
+read -r -a fields <<<"$(./query-packages.sh single -o git-url zfs 2>&1)"
+test ${#fields[@]} -eq 1
+test "${fields[0]}" == 'https://github.com/delphix/zfs.git'
+
+# Expect that "list all" outputs all directory names under packages/
+diff <(ls -1 packages | sort) <(./query-packages.sh list all 2>&1 | sort)
+
+# Expect that outputing git-url for all packages works and that the output
+# length corresponds to the number of packages.
+test "$(ls -1 packages | wc -l)" -eq "$(./query-packages.sh list -o name,git-url all 2>&1 | wc -l)"
+
+# Check that all package lists under package-lists\ can be loaded and that each
+# line of the output of the command actually refers to a package.
+find package-lists -name '*.pkgs' | while read -r list; do
+	list="${list#package-lists/}"
+	./query-packages.sh list "$list" 2>&1 | (
+		cd packages
+		xargs ls
+	) >/dev/null
+done
+
+# Check that querying "appliance" list works
+./query-packages.sh list appliance >/dev/null
+
+# Check that the output from the appliance list contains zfs and
+# delphix-platform packages. Note, we explicitly do not use grep -q here as it
+# exits as soon as a match is found and that causes a broken pipe error as
+# query-packages attempts to write more output.
+./query-packages.sh list appliance | grep zfs >/dev/null
+./query-packages.sh list appliance | grep delphix-platform >/dev/null
+
+# Check that executing query-packages works from another directory.
+# This redoes the "list all" test from above
+cd packages
+diff <(ls -1 | sort) <(../query-packages.sh list all 2>&1 | sort)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,19 @@ jobs:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-shfmt.sh
       - run: make shfmtcheck
+  verify-query-packages:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./.github/scripts/verify-query-packages.sh
+  verify-query-packages-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./.github/scripts/verify-query-packages.sh
+  verify-query-packages-jenkins:
+    runs-on: ubuntu-latest
+    container: jenkins/jenkins
+    steps:
+      - uses: actions/checkout@v1
+      - run: ./.github/scripts/verify-query-packages.sh

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -178,7 +178,7 @@ logmust check_package_exists "$PACKAGE"
 # If the script is called manually, we set it here.
 #
 DEFAULT_REVISION="${DEFAULT_REVISION:-$(default_revision)}"
-DEFAULT_GIT_BRANCH="${DEFAULT_GIT_BRANCH:-master}"
+logmust determine_default_git_branch
 
 echo ""
 echo_bold "===================================================================="

--- a/query-packages.sh
+++ b/query-packages.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
+TOP="$PWD"
+source "$TOP/lib/common.sh"
+
+ALL_OUTPUT_FIELDS=(name git-url dependencies)
+
+function usage() {
+	local output_fields="${ALL_OUTPUT_FIELDS[*]}"
+	(
+		[[ $# != 0 ]] && (
+			echo "$(basename "$0"): $*"
+			echo
+		)
+		echo "Usage:"
+		echo "    $(basename "$0") single [-o FIELDS] PACKAGE"
+		echo "    $(basename "$0") list [-o FIELDS] LIST_FILE"
+		echo ""
+		echo "    Either display information about a single package"
+		echo "    or a package list located under the package-lists"
+		echo "    directory. You can also pass one of the following"
+		echo "    special values to the list command:"
+		echo "      all: displays all known packages"
+		echo "      appliance: displays all packages used by appliance"
+		echo ""
+		echo "    -o  Comma delimited output fields."
+		echo "        Possible values: ${output_fields// /, }."
+		echo "        By default, only print package name."
+		echo "    -h  Show this help."
+	) >&2
+	exit 2
+}
+
+function print_package() {
+	local pkgname="$1"
+	local outarray=()
+	(
+		local field
+		load_package_config "$pkgname" >/dev/null
+		for field in "${ACTIVE_OUTPUT_FIELDS[@]}"; do
+			case "$field" in
+			name) outarray+=("$pkgname") ;;
+			git-url) outarray+=("${DEFAULT_PACKAGE_GIT_URL:-none}") ;;
+			dependencies) outarray+=(none) ;;
+			esac
+		done
+		IFS=$'\t'
+		echo "${outarray[*]}"
+	)
+}
+
+function query_list() {
+	local list="$1"
+	local dups
+
+	# Package list is returned in _RET_LIST by the functions below.
+	# Note that we should always redirect stdout to /dev/null when
+	# calling lib/common.sh functions as they may generate unwanted
+	# debug output.
+	if [[ $list == all ]]; then
+		list_all_packages >/dev/null
+	elif [[ $list == appliance ]]; then
+		# concatenate kernel and userland packages
+		read_package_list "$TOP/package-lists/build/kernel.pkgs" >/dev/null
+		local kernel_list=("${_RET_LIST[@]}")
+		read_package_list "$TOP/package-lists/build/userland.pkgs" >/dev/null
+		_RET_LIST+=("${kernel_list[@]}")
+		# check that there are no duplicates
+		dups=$(printf '%s\n' "${_RET_LIST[@]}" | sort | uniq -d)
+		[[ -z $dups ]] || die "Some apliance packages appear in both" \
+			"build/kernel.pkgs and build/userland.pkgs:\\n${dups}"
+	else
+		read_package_list "$TOP/package-lists/${list}" >/dev/null
+	fi
+}
+
+function do_list() {
+	local list="$1"
+	local pkgname
+
+	query_list "$list"
+	for pkgname in "${_RET_LIST[@]}"; do
+		print_package "$pkgname"
+	done
+}
+
+function do_single() {
+	local pkgname="$1"
+	[[ -n $pkgname ]] || usage "missing argument for pkgname"
+
+	check_package_exists "$pkgname" >/dev/null
+	print_package "$pkgname"
+}
+
+case "$1" in
+list) target=do_list ;;
+single) target=do_single ;;
+*) usage >&2 ;;
+esac
+shift
+
+opt_o=""
+while getopts ':ho:' c; do
+	case "$c" in
+	o)
+		[[ -z $opt_o ]] || usage "-o appears more than once"
+		opt_o="$OPTARG"
+		;;
+	h) usage ;;
+	*) usage "illegal option -- $OPTARG" ;;
+	esac
+done
+shift $((OPTIND - 1))
+
+#
+# Parse list of fields to output
+#
+if [[ -n $opt_o ]]; then
+	ACTIVE_OUTPUT_FIELDS=()
+	for field in $(echo "$opt_o" | tr ',' ' '); do
+		for f in "${ALL_OUTPUT_FIELDS[@]}"; do
+			[[ $f == "$field" ]] && break
+		done
+		if [[ $f == "$field" ]]; then
+			ACTIVE_OUTPUT_FIELDS+=("$field")
+		else
+			usage "invalid output field '$field'"
+		fi
+	done
+else
+	# By default, only print package name
+	ACTIVE_OUTPUT_FIELDS=(name)
+fi
+
+$target "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,8 @@
 TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
+logmust determine_default_git_branch
+
 #
 # Update the sources.list file to point to our internal package mirror. If no
 # mirror url is passed in, then the latest mirror snapshot is used.


### PR DESCRIPTION
See Jira for more context.

### Additional changes
- The `determine_default_git_branch()` function is now called explicitly to avoid having code run when including the lib/common.sh file (especially code that produces output).
- Added new github action to sanity test the query-packages command.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures

## Testing
### Testing the build
linux-pkg-build kernel: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/165/
linux-pkg-build userland: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/572/
linux-pkg-update: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/6/

### Test the new query-packages script
```
~/linux-pkg$ ./query-packages.sh list all
adoptopenjdk
bcc
bpftrace
...
zfs

~/linux-pkg$ ./query-packages.sh list -o name,git-url build/kernel.pkgs
connstat	https://github.com/delphix/connstat.git
delphix-kernel	https://github.com/delphix/delphix-kernel.git
zfs	https://github.com/delphix/zfs.git
```