### PR TITLE
DLPX-69902 [Backport of DLPX-69864 to 6.0.2.1] iSCSI LUN reset command leaks reference and prevents LUN from being deleted

### DIFF
--- a/package-lists/build/kernel.pkgs
+++ b/package-lists/build/kernel.pkgs
@@ -5,4 +5,5 @@
 
 connstat
 delphix-kernel
+linux-prebuilt
 zfs

--- a/packages/linux-prebuilt/config.sh
+++ b/packages/linux-prebuilt/config.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL=none
+
+function _verify_kernel_version() {
+	local requested="$1"
+	local expected="$2"
+
+	if [[ "$requested" != "$expected" ]]; then
+		die "This package expects kernel '$expected' but the build" \
+			"is requesting version '$requested'."
+	fi
+}
+
+#
+# Note: the linux-prebuilt package was created explicitly for the Delphix
+# Appliance version 6.0.2.1. See https://github.com/delphix/linux-pkg/pull/93
+# for more context.
+#
+# It goes into details for why we do this and why only certain kernels are
+# included and not others.
+#
+function fetch() {
+	local pkg_generic="linux-modules-5.0.0-37-generic_5.0.0-37.dx1_amd64.deb"
+	local kvers_generic="5.0.0-37-generic"
+	local pkg_azure="linux-modules-5.0.0-1028-azure_5.0.0-1028.dx1_amd64.deb"
+	local kvers_azure="5.0.0-1028-azure"
+	local pkg_gcp="linux-modules-5.0.0-1028-gcp_5.0.0-1028.dx1_amd64.deb"
+	local kvers_gcp="5.0.0-1028-gcp"
+	local url="http://artifactory.delphix.com/artifactory"
+	url="$url/linux-pkg/linux-prebuilt/6.0.2.1"
+
+	logmust cd "$WORKDIR/artifacts"
+
+	logmust determine_target_kernels
+	check_env KERNEL_VERSIONS
+
+	#
+	# Make sure that the target kernel versions match the versions of the
+	# prebuilt kernel packages, otherwise the prebuilt packages will be
+	# ignored by appliance-build.
+	#
+	local kvers
+	for kvers in $KERNEL_VERSIONS; do
+		case "$kvers" in
+		*-generic) _verify_kernel_version "$kvers" "$kvers_generic" ;;
+		*-azure) _verify_kernel_version "$kvers" "$kvers_azure" ;;
+		*-gcp) _verify_kernel_version "$kvers" "$kvers_gcp" ;;
+		esac
+	done
+
+	logmust wget -nv "$url/$pkg_generic"
+	logmust wget -nv "$url/$pkg_azure"
+	logmust wget -nv "$url/$pkg_gcp"
+}
+
+function build() {
+	return
+	# Nothing to do. The packages are pre-built.
+}


### PR DESCRIPTION
This change specifically targets 6.0.2.1. Three kernel packages were
manually rebuilt, and their revision number was bumped. Those packages
will be used by appliance-build instead of the Ubuntu kernel packages
with the same name.

Note that the `linux-prebuilt` package is only a temporary measure to have those packages included in 6.0.2.1. We will likely need a similar patch in 6.0.3.0. For later releases we will most likely not need this because:
1. The automation for building our own kernel image packages should be completed.
2. The fix should be upstreamed and pulled by Ubuntu.

6.0.2.1 has the following kernel packages:
- 4.15.0-1031-oracle
- 4.15.0-1057-aws
- 5.0.0-1028-azure
- 5.0.0-1028-gcp
- 5.0.0-37-generic

The 4.15 kernel is not affected by this issue, hence we only provide custom packages for generic, azure and gcp.

## Steps used to prepare new packages
1. Build new kernel module (We build the whole linux-modules package)
1.1. Fetch kernel source from Ubuntu, checkout tag for target kernel and apply changes
1.2. Install build dependencies
1.3. Build kernel
  fakeroot debian/rules clean
  time fakeroot debian/rules binary skipdbg=false &>../build.out
1.4. Copy the new module from debian/build/build-generic/. In our case the module is `target_core_mod.ko`.

2. Repack existing kernel package (linux-modules-5.0.0-37-generic in this example)
2.1. Download and unpack kernel
  apt download linux-modules-5.0.0-37-generic
  dpkg-deb -x [deb-file] src
  dpkg-deb -e [deb-file] src/DEBIAN
2.2. Update unpacked files
  Copy new module into src/lib/modules/5.0.0-37-generic/kernel/
  Bump version in DEBIAN/control
  Update changelog with new version (src/usr/share/doc/linux-modules-5.0.0-37-generic/changelog.Debian.gz)
  Update md5sums in src/DEBIAN/md5sum for modified files
2.3. Repack the kernel
  dpkg-deb -b src [new-deb-file]
  We should include the new version in filename

## Code changes to the kernel
The changes to the kernel are minimal. See https://github.com/pzakha/linux/commit/b9a65e0909e7d82879d3998fa19c585e1c8844be
See DLPX-69864 for more details.

## Alternatives considered / rejected
1. Copy custom modules manually to S3 link ingested by appliance-build
Rejected because it is error prone and too much manual work, since we need to do this each time a new linux-pkg-build/kernel job is launched.
2. Add post-upgrade/first-boot code to copy the custom module file into the kernel.
Rejected because hackish, more error prone and requires additional reboot.

## Testing
- See JIRA for testing done for HF-866
- linux-pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/patch/job/kernel/job/pre-push/3/
- ab-pre-push (targets esx, azure, gcp, aws): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3448/

TODO (after push):
- Confirm that the issue is fixed on each platform.

