### PR TITLE
Upstream libkdumpfile branch name update

### DIFF
--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -20,7 +20,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
-UPSTREAM_GIT_BRANCH="master"
+UPSTREAM_GIT_BRANCH="tip"
 
 function prepare() {
 	logmust install_build_deps_from_control_file


### PR DESCRIPTION
Recently libkdumpfile changed its main branch name from
`master` to `tip`. Update the branch definition in our
repo to reflect this change.

## Testing
(before the change) http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/449/

(with change)
userland-update job: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/450/