### PR TITLE
backport: Upstream libkdumpfile branch name update

### DIFF
--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -20,7 +20,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
 UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
-UPSTREAM_GIT_BRANCH="master"
+UPSTREAM_GIT_BRANCH="tip"
 
 function prepare() {
 	logmust install_build_deps_from_control_file


### PR DESCRIPTION
Recently libkdumpfile changed its main branch name from
`master` to `tip`. Update the branch definition in our
repo to reflect this change.

Testing:

update job dry-run:
http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-update/job/master/job/userland/job/update/451/

libkdumpfile was successful on the above run but td-agent failed with the following error:
```
19:34:00  To https://github.com/delphix/omnibus-td-agent.git
19:34:00   ! [rejected]        repo-HEAD -> master (fetch first)
19:34:00  error: failed to push some refs to 'https://****:****@github.com/delphix/omnibus-td-agent.git'
19:34:00  hint: Updates were rejected because the remote contains work that you do
19:34:00  hint: not have locally. This is usually caused by another repository pushing
19:34:00  hint: to the same ref. You may want to first integrate the remote changes
19:34:00  hint: (e.g., 'git pull ...') before pushing again.
19:34:00  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
19:34:00  Error: Push failed.
19:34:00  Error: Failed to push merge for td-agent.
```