### PR TITLE
Route zfs package into recovery environment build

### DIFF
--- a/package-lists/build/kernel.pkgs
+++ b/package-lists/build/kernel.pkgs
@@ -5,9 +5,10 @@
 
 # Note: The following packages should be built first because other packages
 # depend on them being built.
-#  - zfs is required by grub2
+#  - zfs is required by grub2 and recovery-environment
 zfs
 
 connstat
 delphix-kernel
 grub2
+recovery-environment

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -30,4 +30,3 @@ targetcli-fb
 performance-diagnostics
 ptools
 td-agent-prebuilt
-recovery-environment

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -19,8 +19,15 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/recovery-environment.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
+ZFS_DEB_PATH="$TOP/packages/zfs/tmp/artifacts"
 function prepare() {
+	if [ ! "$(ls -A "$ZFS_DEB_PATH")" ]; then
+		logmust "$TOP/buildpkg.sh" zfs
+	fi
+
 	logmust install_build_deps_from_control_file
+	logmust mkdir "$WORKDIR/repo/external-debs/"
+	logmust cp "$ZFS_DEB_PATH/"*.deb "$WORKDIR/repo/external-debs/"
 	return
 }
 


### PR DESCRIPTION
This PR moves the recovery-environment package into the kernel build chain so that it can take the zfs build products to install them into the recovery environment.  This PR is intended to merged in conjunction with https://github.com/delphix/recovery-environment/pull/3.  It has been tested by running ab-pre-push , and by loading the built recovery environment onto a test VM and verifying that the system can import pools while in the recovery environment.