### PR TITLE
Backport: Add grub and recovery environment commits to linux-pkg

### DIFF
--- a/package-lists/build/kernel.pkgs
+++ b/package-lists/build/kernel.pkgs
@@ -3,7 +3,12 @@
 # kernel versions.
 #
 
+# Note: The following packages should be built first because other packages
+# depend on them being built.
+#  - zfs is required by grub2
+zfs
+
 connstat
 delphix-kernel
 linux-prebuilt
-zfs
+grub2

--- a/package-lists/build/kernel.pkgs
+++ b/package-lists/build/kernel.pkgs
@@ -5,10 +5,11 @@
 
 # Note: The following packages should be built first because other packages
 # depend on them being built.
-#  - zfs is required by grub2
+#  - zfs is required by grub2 and recovery-environment
 zfs
 
 connstat
 delphix-kernel
 linux-prebuilt
 grub2
+recovery-environment

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -30,3 +30,4 @@ performance-diagnostics
 ptools
 td-agent-prebuilt
 walinuxagent
+recovery-environment

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -30,4 +30,3 @@ performance-diagnostics
 ptools
 td-agent-prebuilt
 walinuxagent
-recovery-environment

--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -19,3 +19,4 @@ nfs-utils
 python-rtslib-fb
 targetcli-fb
 td-agent
+grub2

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
+
+UPSTREAM_GIT_URL=https://git.launchpad.net/ubuntu/+source/grub2
+UPSTREAM_GIT_BRANCH=applied/ubuntu/bionic-updates
+
+#
+# Install build dependencies for the package.
+#
+function prepare() {
+	if ! dpkg-query --show libzfslinux-dev >/dev/null 2>&1; then
+		echo_bold "libzfs not installed. Building package 'zfs' first."
+		logmust "$TOP/buildpkg.sh" zfs
+	fi
+
+	logmust install_build_deps_from_control_file
+	return
+}
+
+#
+# Build the package.
+#
+function build() {
+	logmust cd "$WORKDIR/repo"
+	if [[ -z "$PACKAGE_VERSION" ]]; then
+		logmust eval PACKAGE_VERSION="$(dpkg-parsechangelog -S Version |
+			awk -F'-' '{print $1}')"
+	fi
+	logmust dpkg_buildpackage_default
+}
+
+#
+# Hook to fetch upstream package changes and merge into our tree.
+#
+function update_upstream() {
+	logmust update_upstream_from_git
+	return
+}

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/recovery-environment.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+	return
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -19,8 +19,15 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/recovery-environment.git"
 DEFAULT_PACKAGE_VERSION=1.0.0
 
+ZFS_DEB_PATH="$TOP/packages/zfs/tmp/artifacts"
 function prepare() {
+	if [ ! "$(ls -A "$ZFS_DEB_PATH")" ]; then
+		logmust "$TOP/buildpkg.sh" zfs
+	fi
+
 	logmust install_build_deps_from_control_file
+	logmust mkdir "$WORKDIR/repo/external-debs/"
+	logmust cp "$ZFS_DEB_PATH/"*.deb "$WORKDIR/repo/external-debs/"
 	return
 }
 

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -162,6 +162,9 @@ function build() {
 	done
 	logmust cd "$WORKDIR"
 	logmust mv "all-packages/"*.deb "artifacts/"
+
+	# Install libzfs which is required to build grub
+	logmust install_pkgs "$WORKDIR/artifacts"/{libnvpair1linux,libuutil1linux,libzfs2linux,libzpool2linux,libzfslinux-dev}_*.deb
 }
 
 function update_upstream() {


### PR DESCRIPTION
This is a nearly-clean backport of the change to the linux-pkg repository that adds grub2 to the linux-pkg build process.  The grub package builds successfully on my test VM.