### PR TITLE
Use gcc 8 for linux-pkg

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -796,3 +796,14 @@ function determine_target_kernels() {
 	echo "Kernel versions to use to build modules:"
 	echo "  $KERNEL_VERSIONS"
 }
+
+#
+# Install gcc 8, and make it the default
+#
+function install_gcc8() {
+	logmust install_pkgs gcc-8 g++-8
+	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
+		/usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
+		/usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+}

--- a/setup.sh
+++ b/setup.sh
@@ -83,5 +83,12 @@ logmust install_pkgs \
 
 logmust install_shfmt
 
+#
+# Starting with kernel 5.4, gcc 7 can no longer compile kernel modules, so
+# install gcc 8
+# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1849348
+#
+logmust install_gcc8
+
 logmust git config --global user.email "eng@delphix.com"
 logmust git config --global user.name "Delphix Engineering"


### PR DESCRIPTION
The 5.4 kernel headers define CONFIG_CC_HAS_ASM_INLINE, which prevents
kernel modules from being compiled with gcc 7. This is
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1849348

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build was run locally and any changes were pushed
- [x] Lint has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: TOOL-9951
The linux-package-mirror-sync job stopped working due to the above mentioned bug. Package creation
for kernel modules would fail.

## What is the new behavior?
With the new compiler, kernel module compilation works again.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
linux-package-mirror-sync test using this change:
http://collins.d.delphix.com:24041/job/devops-gate/job/master/job/linux-package-mirror-sync/job/master/job/mirror2-sync/7/consoleFull

linux-pkg-build jobs for kernel and userland
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/624/consoleFull
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/kernel/job/pre-push/247/consoleFull

appliance-build-orchestrator jobs (using artifacts from the above jobs) on dcol1 and DCoA:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3837/consoleFull
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3838/console
