### PR TITLE
[Backport to 6.0.5.0] Use gcc 8 for linux-pkg (#107)

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -796,3 +796,14 @@ function determine_target_kernels() {
 	echo "Kernel versions to use to build modules:"
 	echo "  $KERNEL_VERSIONS"
 }
+
+#
+# Install gcc 8, and make it the default
+#
+function install_gcc8() {
+	logmust install_pkgs gcc-8 g++-8
+	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
+		/usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
+		/usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+}

--- a/setup.sh
+++ b/setup.sh
@@ -83,5 +83,12 @@ logmust install_pkgs \
 
 logmust install_shfmt
 
+#
+# Starting with kernel 5.4, gcc 7 can no longer compile kernel modules, so
+# install gcc 8
+# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1849348
+#
+logmust install_gcc8
+
 logmust git config --global user.email "eng@delphix.com"
 logmust git config --global user.name "Delphix Engineering"


### PR DESCRIPTION
The 5.4 kernel headers define CONFIG_CC_HAS_ASM_INLINE, which prevents
kernel modules from being compiled with gcc 7.

Clean cherry-pick. This work is required for bumping our kernel in 6.0.5.0.

## Testing
 - linux-pkg-build userland: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/stage/job/userland/job/pre-push/92/
 - linux-pkg-build kernel: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/stage/job/kernel/job/pre-push/49/
 - ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3943/