### PR TITLE
Add savedump userland package

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -25,6 +25,7 @@ gdb-python
 makedumpfile
 nfs-utils
 python-rtslib-fb
+savedump
 sdb
 targetcli-fb
 performance-diagnostics

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/savedump.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+function prepare() {
+	logmust install_pkgs \
+		git \
+		python3-distutils
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
Relevant change in Delphix platform: https://github.com/delphix/delphix-platform/pull/246

### Testing:

linux-pkg userland job: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/637/
appliance-build job: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3947/
manual testing on VM group created by appliance-build job above:
```
delphix@ip-10-110-232-241:~$ savedump -h
usage: savedump [-h] dump

Archive Linux crash dumps

positional arguments:
  dump        the dump to be archived

optional arguments:
  -h, --help  show this help message and exit
```
