### PR TITLE
DLPX-71696 [Backport of DLPX-71695 to 6.0.5.0] Update kernel for 6.0.5.0

### DIFF
--- a/packages/linux-prebuilt/config.sh
+++ b/packages/linux-prebuilt/config.sh
@@ -30,25 +30,25 @@ function _verify_kernel_version() {
 
 #
 # Note: the linux-prebuilt package was created explicitly for the Delphix
-# Appliance version 6.0.3.0. However, this fix could also apply to some later
+# Appliance version 6.0.5.0. However, this fix could also apply to some later
 # versions of the product as long as we keep the linux-package-mirror frozen.
 # See https://github.com/delphix/linux-pkg/pull/96 for more context.
 #
 # It goes into details for why we do this.
 #
 function fetch() {
-	local pkg_generic="linux-modules-5.3.0-53-generic_5.3.0-53.dx2_amd64.deb"
-	local kvers_generic="5.3.0-53-generic"
-	local pkg_aws="linux-modules-5.3.0-1019-aws_5.3.0-1019.dx2_amd64.deb"
-	local kvers_aws="5.3.0-1019-aws"
-	local pkg_azure="linux-modules-5.3.0-1022-azure_5.3.0-1022.dx2_amd64.deb"
-	local kvers_azure="5.3.0-1022-azure"
-	local pkg_gcp="linux-modules-5.3.0-1020-gcp_5.3.0-1020.dx2_amd64.deb"
-	local kvers_gcp="5.3.0-1020-gcp"
-	local pkg_oracle="linux-modules-5.3.0-1018-oracle_5.3.0-1018.dx2_amd64.deb"
-	local kvers_oracle="5.3.0-1018-oracle"
+	local pkg_generic="linux-modules-5.4.0-42-generic_5.4.0-42.dx1_amd64.deb"
+	local kvers_generic="5.4.0-42-generic"
+	local pkg_aws="linux-modules-5.3.0-1033-aws_5.3.0-1033.dx1_amd64.deb"
+	local kvers_aws="5.3.0-1033-aws"
+	local pkg_azure="linux-modules-5.3.0-1035-azure_5.3.0-1035.dx1_amd64.deb"
+	local kvers_azure="5.3.0-1035-azure"
+	local pkg_gcp="linux-modules-5.4.0-1021-gcp_5.4.0-1021.dx1_amd64.deb"
+	local kvers_gcp="5.4.0-1021-gcp"
+	local pkg_oracle="linux-modules-5.4.0-1021-oracle_5.4.0-1021.dx1_amd64.deb"
+	local kvers_oracle="5.4.0-1021-oracle"
 	local url="http://artifactory.delphix.com/artifactory"
-	url="$url/linux-pkg/linux-prebuilt/6.0.3.0/dx2"
+	url="$url/linux-pkg/linux-prebuilt/6.0.5.0/dx1"
 
 	logmust cd "$WORKDIR/artifacts"
 


### PR DESCRIPTION
I've rebuilt the latest linux kernel modules packages for 6.0/stage with our iSCSI fixes for DLPX-69953.

I've used the same procedure as for https://github.com/delphix/linux-pkg/pull/96. See https://github.com/pzakha/linux/tree/6050-generic for an overview of the changes. Changes for other platforms are published to branches `6050-<flavour>`. Note that DLPX-69864 has already been integrated upstream so you will not see a Delphix commit for it.

@grodr has synced the 6.0/stage linux package mirror (http://linux-package-mirror.delphix.com/6.0/stage/0fb27f0b/) without updating the "latest" 6.0/stage url. I've first used that mirror link to discover the latest versions of the kernel, then later in my testing.

Latest kernel versions are:
- 5.4.0-42-generic
- 5.3.0-1033-aws
- 5.3.0-1035-azure
- 5.4.0-1021-gcp
- 5.4.0-1021-oracle

## Dependencies

We must update the 6.0/stage linux-package-mirror "latest" link to http://linux-package-mirror.delphix.com/6.0/stage/0fb27f0b/ at the same time as we push this change.

## Testing

linux-pkg kernel build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/6.0/job/stage/job/kernel/job/pre-push/50/

ab-pre-push:
- aws, with tests: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3970/
- esx, with tests: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3974 (note: failure is with infrastructure, but tests have passed)
- azure, gcp & oracle, without tests: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3972 (note: failure fetching packages from Ubuntu, but it was after images for each platform were successfully built)


