### PR TITLE
savedump and crash-util for 6.0/stage

### DIFF
--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -16,6 +16,7 @@ delphix-sso-app
 bpftrace
 challenge-response
 cloud-init
+crash
 crash-python
 crypt-blowfish
 delphix-platform

--- a/package-lists/build/userland.pkgs
+++ b/package-lists/build/userland.pkgs
@@ -25,6 +25,7 @@ gdb-python
 makedumpfile
 nfs-utils
 python-rtslib-fb
+savedump
 sdb
 targetcli-fb
 performance-diagnostics

--- a/package-lists/update/userland.pkgs
+++ b/package-lists/update/userland.pkgs
@@ -13,6 +13,7 @@
 
 bpftrace
 cloud-init
+crash
 drgn
 libkdumpfile
 nfs-utils

--- a/packages/crash/config.sh
+++ b/packages/crash/config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/crash.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+UPSTREAM_GIT_URL="https://github.com/crash-utility/crash.git"
+UPSTREAM_GIT_BRANCH="master"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/savedump.git"
+DEFAULT_PACKAGE_VERSION=1.0.0
+
+function prepare() {
+	logmust install_pkgs \
+		git \
+		python3-distutils
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
Clean cherry-picks of 375bc36cc3aad40e13e4f79467f17ef119d75d7b and fcb13c94014273ee94596591381702944c9dda3e

### Testing

Using change in delphix-platform 6.0/stage -> https://github.com/delphix/delphix-platform/pull/247

linux-pkg userland job: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/643/
ab-pre-push with s3 link from above: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3987/flowGraphTable/

manual testing in provisioned VM:
```
delphix@ip-10-110-253-150:~$ ls -l /usr/bin/crash
-rwxr-xr-x 1 root root 8364632 Sep  9 23:25 /usr/bin/crash
delphix@ip-10-110-253-150:~$ ls -l /usr/bin/savedump
-rwxr-xr-x 1 root root 387 Sep  9 23:45 /usr/bin/savedump
```