### PR TITLE
Fetch dependency of linux dbgsym package when downloading kernel packages

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -995,12 +995,12 @@ function fetch_kernel_from_apt_for_version() {
 	# kernel packages.
 	#
 	local deb dep deps
-	for deb in *.deb; do
+	for deb in *deb; do
 		deps=$(dpkg-deb -f "$deb" Depends | tr -d ' ' | tr ',' ' ') ||
 			die "failed to get dependencies for $deb"
 		for dep in $deps; do
 			case "$dep" in
-			*-headers-* | *-tools-*)
+			*-headers-* | *-tools-* | *-dbgsym)
 				logmust apt-get download "$dep"
 				;;
 			esac


### PR DESCRIPTION
The idea for the linux-pkg's linux-kernel-* packages, is that we will store in S3 all of the linux-kernel packages required to build the Delphix Appliance, without relying on the linux-package-mirror snapshot that is passed to appliance-build to contain them.

Some linux-kernel packages have dependencies on other linux-kernel packages. It seems that in some cases the dbgsym package has dependencies on another dbgsym package with a slightly different naming convention, and we were not downloading it.

Here's an example:
`linux-image-5.4.0-48-generic-dbgsym` depends on `linux-image-unsigned-5.4.0-48-generic-dbgsym`.

Note that we've already had some logic to deal with a similar issue that we had with the "tools" and "headers" packages, so this just extends the same logic to the dbgsym package.

## Testing
build-kernel: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-kernel/job/pre-push/3/console
List of debs produced (i.e. downloaded) by the `linux-kernel-generic` package:
```
linux-headers-5.4.0-48-generic_5.4.0-48.52~18.04.1_amd64.deb
linux-hwe-5.4-headers-5.4.0-48_5.4.0-48.52~18.04.1_all.deb
linux-hwe-5.4-tools-5.4.0-48_5.4.0-48.52~18.04.1_amd64.deb
linux-image-5.4.0-48-generic-dbgsym_5.4.0-48.52~18.04.1_amd64.ddeb
linux-image-5.4.0-48-generic_5.4.0-48.52~18.04.1_amd64.deb
linux-image-unsigned-5.4.0-48-generic-dbgsym_5.4.0-48.52~18.04.1_amd64.ddeb
linux-modules-5.4.0-48-generic_5.4.0-48.52~18.04.1_amd64.deb
linux-tools-5.4.0-48-generic_5.4.0-48.52~18.04.1_amd64.deb
```