### PR TITLE
Download linux-cloud-tools package when fetching kernel packages

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -990,6 +990,15 @@ function fetch_kernel_from_apt_for_version() {
 		"linux-tools-${kernel_version}"
 
 	#
+	# For the azure kernel, we also want to get the linux-cloud-tools
+	# package. Not that we cannot do this indiscriminately since some
+	# kernel flavors do not come with a linux-cloud-tools package.
+	#
+	if [[ "$kernel_version" == *azure ]]; then
+		logmust apt-get download "linux-cloud-tools-${kernel_version}"
+	fi
+
+	#
 	# Fetch direct dependencies of the downloaded debs. Some of those
 	# dependencies have a slightly different naming scheme than the other
 	# kernel packages.


### PR DESCRIPTION
This is related to https://github.com/delphix/delphix-kernel/pull/16.

In terms of impact, this change is very similar to https://github.com/delphix/linux-pkg/pull/125, i.e. the build will likely keep working without this change but we would want to have it for the sake of completeness / correctness.

## Testing
build-kernel: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-kernel/job/pre-push/8/console