### PR TITLE
DLPX-73310 linux-pkg: enable building from release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ of some of the scripts defined above.
 
 * **DEFAULT_GIT_BRANCH**: The product branch that is being built or updated is
   typically stored in the file `branch.config`, however it can be overridden via
-  DEFAULT_GIT_BRANCH. The product branch is used in multiple instances. When
+  DEFAULT_GIT_BRANCH. It can either be set to a development branch, such as
+  "master" or "6.0/stage", or a release tag, such as "release/6.0.6.0".
+  The product branch is used in multiple instances. When
   running [setup.sh](#setupsh), it will determine what linux-package-mirror
   link to use when fetching packages from apt (although those links can be
   overridden via DELPHIX_PACKAGE_MIRROR_MAIN and
@@ -308,6 +310,14 @@ of some of the scripts defined above.
   sub-directory you can instruct linux-pkg to fetch artifacts of build
   dependencies produced by the developer Jenkins instance instead of the
   production one.
+
+* **DEPENDENCIES_BASE_URL**: When fetching artifacts from other linux-pkg
+  packages that are marked as dependencies of a package, we look for a
+  specific s3 path based on what product branch or version we are building for,
+  which is defined by DEFAULT_GIT_BRANCH. If DEPENDENCIES_BASE_URL is left
+  unset, then the path will be determined automatically. DEPENDENCIES_BASE_URL
+  is most useful when set to the input-artifacts of a previous appliance-build
+  run, i.e. "s3://.../input-artifacts/combined-packages/packages".
 
 ## Package Definition
 

--- a/setup.sh
+++ b/setup.sh
@@ -31,11 +31,15 @@ configure_apt_sources() {
 
 	if [[ -z "$primary_url" ]] || [[ -z "$secondary_url" ]]; then
 		local latest_url="http://linux-package-mirror.delphix.com/"
-		latest_url+="${DEFAULT_GIT_BRANCH}/latest/"
-		package_mirror_url=$(curl -LfSs -o /dev/null -w '%{url_effective}' \
-			"$latest_url" || die "Could not curl $latest_url")
-		# Remove trailing slash, if present.
-		package_mirror_url="${package_mirror_url%/}"
+		if is_release_branch; then
+			package_mirror_url="${latest_url}${DEFAULT_GIT_BRANCH}"
+		else
+			latest_url+="${DEFAULT_GIT_BRANCH}/latest/"
+			package_mirror_url=$(curl -LfSs -o /dev/null -w '%{url_effective}' \
+				"$latest_url" || die "Could not curl $latest_url")
+			# Remove trailing slash, if present.
+			package_mirror_url="${package_mirror_url%/}"
+		fi
 		[[ -z "$primary_url" ]] && primary_url="${package_mirror_url}/ubuntu"
 		[[ -z "$secondary_url" ]] && secondary_url="${package_mirror_url}/ppas"
 	fi


### PR DESCRIPTION
When using a release tag in DEFAULT_GIT_BRANCH the linux-package-mirror
link and the base url for fetching build dependencies are now properly
set up.

## Testing
- ab-pre-push (rebuilding zfs + dependenciees & targetcli-fb): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4395
- manually tested that the logic works on bootstrap VM. Note that given that we do not currently have a release which uses "combined-packages" artifacts, I had to provide a custom `DEPENDENCIES_BASE_URL` link to make it work; that said I verified that the logic from `determine_dependencies_base_url()` should be compatible with artifacts that will be generated for 6.0.6.0 and later.