### PR TITLE
DLPX-73657 linux-pkg auto-update: git tags for hwe kernel now has the same format as other kernel flavours

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -220,24 +220,24 @@ function kernel_update_upstream() {
 	# Note that "generic" (used mainly ESX) is a special
 	# case as we are currently using the HWE kernel image.
 	#
-	local tag_prefix
+	local tag_prefix_flavour
 	if [[ "${platform}" == generic ]] &&
 		[[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
-		tag_prefix="Ubuntu-hwe-${kernel_version}-${abinum}"
+		tag_prefix_flavour="Ubuntu-hwe"
 	elif [[ "${platform}" == aws ]] ||
 		[[ "${platform}" == azure ]] ||
 		[[ "${platform}" == gcp ]] ||
 		[[ "${platform}" == oracle ]]; then
-
-		local kvers_major kvers_minor short_kvers
-		kvers_major=$(echo "${kernel_version}" | cut -d '.' -f 1)
-		kvers_minor=$(echo "${kernel_version}" | cut -d '.' -f 2)
-		short_kvers="${kvers_major}.${kvers_minor}"
-
-		tag_prefix="Ubuntu-${platform}-${short_kvers}-${kernel_version}-${abinum}"
+		tag_prefix_flavour="Ubuntu-${platform}"
 	else
 		die "assertion: unexpected platform: ${platform}"
 	fi
+
+	local tag_prefix kvers_major kvers_minor short_kvers
+	kvers_major=$(echo "${kernel_version}" | cut -d '.' -f 1)
+	kvers_minor=$(echo "${kernel_version}" | cut -d '.' -f 2)
+	short_kvers="${kvers_major}.${kvers_minor}"
+	tag_prefix="${tag_prefix_flavour}-${short_kvers}-${kernel_version}-${abinum}"
 	echo "note: upstream tag prefix used: ${tag_prefix}"
 
 	#


### PR DESCRIPTION
In the auto-update logic for the linux kernel, we rely on Ubuntu to tag their new kernel releases using a certain tag format. That format has changed for HWE kernels. It used to be:
```
Ubuntu-hwe-5.3.0-69.65 
```
Now it is:
```
Ubuntu-hwe-5.4-5.4.0-31.35_18.04.2 
```
Notice the "5.4" prefixing the kernel version.

This is now the same format that Ubuntu is using for other kernel flavours.

## Testing
Before: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-generic/1/
With this fix: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-generic/2/