### PR TITLE
DLPX-73763 Fix kernel build and auto-sync logic

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -61,7 +61,8 @@ function kernel_build() {
 	#       debian/rules command, the rightmost declaration
 	#       is the one that is actually used.
 	#
-	local debian_rules_extra_args="$2"
+	shift
+	local debian_rules_extra_args=("$@")
 
 	logmust cd "$WORKDIR/repo"
 
@@ -91,7 +92,7 @@ function kernel_build() {
 	#
 	local canonical_abinum delphix_abinum kernel_release kernel_version
 	canonical_abinum=$(fakeroot debian/rules printenv | grep -E '^abinum ' | cut -d= -f2 | tr -d '[:space:]')
-	delphix_abinum="dlpx-$(date -u +"%Y%m%dt%H%M%S")-$(git rev-parse --short HEAD)-${canonical_abinum}"
+	delphix_abinum="${canonical_abinum}-$(date -u +"dx%Y%m%d%H")-$(git rev-parse --short HEAD)"
 	kernel_release=$(fakeroot debian/rules printenv | grep -E '^release ' | cut -d= -f2 | tr -d '[:space:]')
 
 	#
@@ -113,20 +114,35 @@ function kernel_build() {
 	# disable_d_i=true
 	#   This prevents udeb packages from being built as they are
 	#   not consumed by the Delphix Appliance.
+	# do_dkms_*=false
+	#   This disables the build of various out-of-tree kernel modules
+	#   that we do not use in our product or that we provide separately.
 	#
-	local debian_rules_args="skipdbg=false uefi_signed=false disable_d_i=true flavours=$platform abinum=${delphix_abinum} ${debian_rules_extra_args}"
+	local debian_rules_args=(
+		"skipdbg=false"
+		"uefi_signed=false"
+		"disable_d_i=true"
+		"do_zfs=false"
+		"do_dkms_nvidia=false"
+		"do_dkms_nvidia_server=false"
+		"do_dkms_vbox=false"
+		"do_dkms_wireguard=false"
+		"flavours=$platform"
+		"abinum=${delphix_abinum}"
+	)
+	debian_rules_args+=("${debian_rules_extra_args[@]}")
 
 	#
 	# Clean up everything generated so far and recreate the
 	# final control file with the arguments that we want.
 	#
-	logmust fakeroot debian/rules clean ${debian_rules_args}
+	logmust fakeroot debian/rules clean "${debian_rules_args[@]}"
 
 	#
 	# Print the environment configuration solely for
 	# debugging purposes.
 	#
-	logmust fakeroot debian/rules printenv ${debian_rules_args}
+	logmust fakeroot debian/rules printenv "${debian_rules_args[@]}"
 
 	#
 	# The default value of the tool argument for mk-build-deps
@@ -139,7 +155,7 @@ function kernel_build() {
 	local build_deps_tool="apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes"
 	logmust sudo mk-build-deps --install debian/control --tool "${build_deps_tool}"
 
-	logmust fakeroot debian/rules "binary" ${debian_rules_args}
+	logmust fakeroot debian/rules "binary" "${debian_rules_args[@]}"
 
 	logmust cd "$WORKDIR"
 	logmust mv ./*deb "artifacts/"
@@ -274,8 +290,18 @@ function kernel_update_upstream() {
 
 	logmust git fetch upstream "+refs/tags/${upstream_tag}:refs/tags/${upstream_tag}"
 
+	#
+	# Note that we add '^{}' at the end to dereference the tag recursively
+	# until it arrives to an actual commit. This is needed in case the
+	# tag points to an anotated tag object which contains extra information
+	# such as a PGP signature. That annoted tag will in turn reference the
+	# actual commit, which will be returned when appending ^{}.
+	# upstream-HEAD will be pointing to the commit directly rather than the
+	# annoted tag object, so if we want to compare the two we need to query
+	# for the dereferenced commit. See 'git help gitrevisions' for more info.
+	#
 	local upstream_tag_commit
-	upstream_tag_commit="$(git rev-parse "refs/tags/${upstream_tag}")" ||
+	upstream_tag_commit="$(git rev-parse "refs/tags/${upstream_tag}^{}")" ||
 		die "couldn't get commit of tag ${upstream_tag}"
 	echo "note: upstream tag: ${upstream_tag}, commit ${upstream_tag_commit}"
 


### PR DESCRIPTION
There are 3 distinct changes here:
### 1. Stop building third party DKMS modules when building kernel
When the Ubuntu kernel is built, it also pulls some 3rd party kernel modules out-of-tree, compiles them separately and packages them along with the kernel package. Not only do we not need those 3rd party kernel modules in our kernel, but they also introduce additional 3rd party dependencies to our build process. Recently, when trying to build the latest kernel one of those dependencies, nvidia, could not be located on the Ubuntu servers and so would cause the build to fail:
```
18:43:28  II: dkms-build downloading nvidia-390 (nvidia-kernel-source-390_390.141-0ubuntu0~0.20.04.1_amd64.deb)
18:43:28  II: fetching https://launchpad.net/ubuntu/+archive/primary/+files/nvidia-kernel-source-390_390.141-0ubuntu0~0.20.04.1_amd64.deb
18:43:29  curl: (22) The requested URL returned error: 404 Not Found
```

### 2. Fix `kernel_update_upstream()` function that doesn't correctly detects when upstream has been modified.
The current logic that determines whether there are new changes upstream does the following:
a) Determine what's the latest kernel version provided by Ubuntu for the target platform, by inspecting the `linux-image-<platform>` meta-package in the package archive.
b) Determine what's the git tag that is associated with the latest kernel version
c) Compare the commit that the git tag points to with the commit that our `upstreams/master` branch points to. If the commits match then we are up-to-date.

There is a problem in how we determine the commit the git tag points to. If the git tag points to an "annotated tag" object then `git rev-parse <tag>` will return the hash of the annotated tag object rather than the commit pointed to by the tag. This is fixed by running `git rev-parse <tag>^{}` instead, which returns the commit that the tag object points to regardless of whether it is a simple tag or an annotated tag.

### 3. Modify the kernel version string for our kernels built in-house.
Delphix modifies the kernel version string, as returned by `uname -r`, from the original Ubuntu string by adding 2 additional pieces of information: the timestamp of the kernel build and the git hash of the commit being built.
I'm proposing 2 changes to the Delphix kernel string:
a) Make it shorter
b) Move the "abi" number to be right after the major kernel version instead of at the end, so that kernel versions get sorted by this number first, rather than the timestamp. Note that this will not modify how the system decides which kernel is the latest (and therefore which one to use) as that is handled separately via https://github.com/delphix/grub2/pull/10.
Here's an example of the changes:
```
Ubutnu:      5.4.0-1035-aws
Delphix Old: 5.4.0-dlpx-20210115t165532-095a724c7-1035-aws
Delphix New: 5.4.0-1035-dx2021011516-095a724c7-aws
```
Note that the new timestamp drops the minutes and seconds part as they are not really necessary. We could even potentially drop the hour part but that could make some developer workflows harder.

## Testing
- `kernel_update_upstream()` change detection logic: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-aws/5/console
- Dropping dkms packages & new version string:
  build packages: http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-packages/job/pre-push/117/
  run tests: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4618
- auto-update was run successfully for all kernels:
  http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-aws/5/
  http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-generic/6/
  http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-gcp/4
  http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-azure/4
  http://collins.d.delphix.com:21968/job/devops-gate/job/master/job/linux-pkg/job/master/job/update-package/job/linux-kernel-oracle/4/