### PR TITLE
DLPX-73791 Use linux kernel packages built in-house

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -35,7 +35,7 @@ export UBUNTU_DISTRIBUTION="bionic"
 #  2. "archive": dowloading from apt
 #  3. "prebuilt": pre-built kernel stored in artifactory
 #
-export DEFAULT_LINUX_KERNEL_PACKAGE_SOURCE="archive"
+export DEFAULT_LINUX_KERNEL_PACKAGE_SOURCE="delphix"
 
 # shellcheck disable=SC2086
 function enable_colors() {

--- a/package-lists/update/main.pkgs
+++ b/package-lists/update/main.pkgs
@@ -17,6 +17,11 @@ crash
 drgn
 grub2
 libkdumpfile
+linux-kernel-aws
+linux-kernel-azure
+linux-kernel-gcp
+linux-kernel-generic
+linux-kernel-oracle
 makedumpfile
 nfs-utils
 python-rtslib-fb


### PR DESCRIPTION
This enables the usage of our in-house linux kernel.

## Testing
- Build packages & test on aws: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/685/
- Build appliance for esx, aws, gcp, oci, azure: http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/686
- Test upgrade on aws: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/upgrade-testing/4368/