### PR TITLE
CP-4543 main.pkgs update follow on

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -13,6 +13,7 @@ crypt-blowfish
 delphix-platform
 delphix-sso-app
 drgn
+docker-python-image
 gdb-python
 grub2
 libkdumpfile


### PR DESCRIPTION
Adding `docker-python-image` to main.pkgs after the package's job is generated.

After the job was generated the first run was successful:
http://ops.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-package/job/docker-python-image/job/post-push/1/

Also ran combine-packages job to verify everything gets put together properly: 
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/combine-packages/job/pre-push/299/console

In the COMPONENTS artifacts (http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/combine-packages/job/pre-push/299/artifact/COMPONENTS/*view*/) an entry for the new package exists:
docker-python-image: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/linux-pkg/master/build-package/docker-python-image/post-push/1