### PR TITLE
TOOL-11267 Remove DEFAULT_PACKAGE_VERSION field from linux-pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,30 +346,6 @@ Here is a list of variables that can be defined for a package:
   "dep" is the dependency's name. A special value can be passed for packages
   that target all the supported flavours of the linux-kernel: `@linux-kernel`.
 
-* **DEFAULT_PACKAGE_GIT_BRANCH**: (DEPRECATED) Default git branch to use when
-  fetching from or pushing to `DEFAULT_PACKAGE_GIT_URL`. This should be
-  typically left unset. The branch to fetch the package from defaults
-  to the value of the environment variable `DEFAULT_BRANCH`, which itself
-  defaults to "master".
-  WARNING: do not set this parameter unless you know exactly what you are doing,
-  as our current versioning convention is to use DEFAULT_BRANCH for each
-  package. This parameter may be removed in the future.
-
-* **DEFAULT_PACKAGE_VERSION**: (Optional) The version of the package is set to
-  this value when it is built. **Note:** If this field is not set, then you
-  should provide a mechanism in the [build](#build-hook) hook to auto-determine
-  the version from the source code.
-  WARNING: This parameter will be removed in the near future, as we will rely on
-  the changelog contained in the package's repository to get the package version
-  in the future.
-
-* **DEFAULT_PACKAGE_REVISION**: (Optional) The revision of the package is set to
-  this value when it is built (note that the full version of a package is
-  "_VERSION-REVISION_"). If unset, it defaults to value of environment variable
-  DEFAULT_REVISION.
-  WARNING: This parameter is currently unused and will be removed in the near
-  future.
-
 * **UPSTREAM_SOURCE_PACKAGE**: (Optional) Third-party packages that have an
   [update_upstream](#update-upstream-hook) hook and are updated from an Ubuntu
   source package should set this to the name of the source package.
@@ -644,15 +620,6 @@ use the `install_pkgs()` lib function to install packages.
 Next step is to add a [build()](#build) hook. It is recommended to use the
 `dpkg_buildpackage_default()` function.
 
-Then you'll need to provide the version of the package. For packages created
-from an Ubuntu source package, it is advised to use the same version as was set
-in the source package. For other packages you can use any version you like (e.g.
-`1.0.0`). The version must be provided with:
-
-```
-DEFAULT_PACKAGE_VERSION="<version>"
-```
-
 Note that if you are using an Ubuntu source package, you should now be ready to
 build the package.
 
@@ -717,14 +684,10 @@ In `config.sh`, you'll need to define two variables:
 * `DEFAULT_PACKAGE_GIT_URL`: the `https://` git URL for the source code of the
   package.
 
-* `DEFAULT_PACKAGE_VERSION`: the version of the package. If unsure, just
-  use `1.0.0`.
-
 e.g.:
 
 ```
 DEFAULT_PACKAGE_GIT_URL="https://delphix.gitlab.com/<user>/<package>"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 ```
 
 #### Step 2. Add package hooks

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ logmust check_running_system
 function usage() {
 	[[ $# != 0 ]] && echo "$(basename "$0"): $*"
 	echo "Usage: $(basename "$0") [-ch] [-g pkg_git_url]"
-	echo "         [-b pkg_git_branch] [-v pkg_version] [-r pkg_revision]"
+	echo "         [-b pkg_git_branch] [-r pkg_revision]"
 	echo "         package"
 	echo ""
 	echo "  This script builds a package based on its config.sh. If '-u'"
@@ -36,7 +36,6 @@ function usage() {
 	echo "    -g  override default git url for the package."
 	echo "    -b  override default git branch for the package."
 	echo "    -c  also run package's checkstyle hook."
-	echo "    -v  override default version for package."
 	echo "    -r  override default revision for package."
 	echo "    -h  display this message and exit."
 	echo ""
@@ -45,15 +44,13 @@ function usage() {
 
 unset PARAM_PACKAGE_GIT_URL
 unset PARAM_PACKAGE_GIT_BRANCH
-unset PARAM_PACKAGE_VERSION
 unset PARAM_PACKAGE_REVISION
 
 do_checkstyle=false
-while getopts ':b:cg:hr:v:' c; do
+while getopts ':b:cg:hr:' c; do
 	case "$c" in
 	g) export PARAM_PACKAGE_GIT_URL="$OPTARG" ;;
 	b) export PARAM_PACKAGE_GIT_BRANCH="$OPTARG" ;;
-	v) export PARAM_PACKAGE_VERSION="$OPTARG" ;;
 	r) export PARAM_PACKAGE_REVISION="$OPTARG" ;;
 	c) do_checkstyle=true ;;
 	h) usage >&2 ;;

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -223,12 +223,9 @@ function reset_package_config_variables() {
 	local vars="
 	PACKAGE_GIT_URL
 	PACKAGE_GIT_BRANCH
-	PACKAGE_GIT_VERSION
-	PACKAGE_GIT_REVISION
+	PACKAGE_VERSION
+	PACKAGE_REVISION
 	DEFAULT_PACKAGE_GIT_URL
-	DEFAULT_PACKAGE_GIT_BRANCH
-	DEFAULT_PACKAGE_GIT_VERSION
-	DEFAULT_PACKAGE_GIT_REVISION
 	PACKAGE_DEPENDENCIES
 	UPSTREAM_SOURCE_PACKAGE
 	UPSTREAM_GIT_URL
@@ -364,7 +361,7 @@ function load_package_config() {
 
 #
 # Use different config sources to determine the values for:
-#   PACKAGE_GIT_URL, PACKAGE_GIT_BRANCH, PACKAGE_VERSION, PACKAGE_REVISION
+#   PACKAGE_GIT_URL, PACKAGE_GIT_BRANCH, PACKAGE_REVISION
 #
 # The sources for the config, in decreasing order of priority, are:
 #   1. Command line parameters passed to build script.
@@ -401,27 +398,11 @@ function get_package_config_from_env() {
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_GIT_BRANCH="${!var}"
 		echo "PACKAGE_GIT_BRANCH set to value of ${var}"
-	elif [[ -n "$DEFAULT_PACKAGE_GIT_BRANCH" ]]; then
-		PACKAGE_GIT_BRANCH="$DEFAULT_PACKAGE_GIT_BRANCH"
-		echo "PACKAGE_GIT_BRANCH set to value of" \
-			"DEFAULT_PACKAGE_GIT_BRANCH"
 	fi
 
 	if [[ -z "$PACKAGE_GIT_BRANCH" ]]; then
 		PACKAGE_GIT_BRANCH="$DEFAULT_GIT_BRANCH"
 		echo "PACKAGE_GIT_BRANCH set to value of DEFAULT_GIT_BRANCH"
-	fi
-
-	var="${PACKAGE_PREFIX}_VERSION"
-	if [[ -n "$PARAM_PACKAGE_VERSION" ]]; then
-		PACKAGE_VERSION="$PARAM_PACKAGE_VERSION"
-		echo "PACKAGE_VERSION passed from '-v'"
-	elif [[ -n "${!var}" ]]; then
-		PACKAGE_VERSION="${!var}"
-		echo "PACKAGE_VERSION set to value of ${var}"
-	elif [[ -n "$DEFAULT_PACKAGE_VERSION" ]]; then
-		PACKAGE_VERSION="$DEFAULT_PACKAGE_VERSION"
-		echo "PACKAGE_VERSION set to value of DEFAULT_PACKAGE_VERSION"
 	fi
 
 	var="${PACKAGE_PREFIX}_REVISION"
@@ -431,9 +412,6 @@ function get_package_config_from_env() {
 	elif [[ -n "${!var}" ]]; then
 		PACKAGE_REVISION="${!var}"
 		echo "PACKAGE_REVISION set to value of ${var}"
-	elif [[ -n "$DEFAULT_PACKAGE_REVISION" ]]; then
-		PACKAGE_REVISION="$DEFAULT_PACKAGE_REVISION"
-		echo "PACKAGE_REVISION set to value of DEFAULT_PACKAGE_REVISION"
 	fi
 
 	if [[ -z "$PACKAGE_REVISION" ]]; then
@@ -443,13 +421,11 @@ function get_package_config_from_env() {
 
 	export PACKAGE_GIT_URL
 	export PACKAGE_GIT_BRANCH
-	export PACKAGE_VERSION
 	export PACKAGE_REVISION
 
 	echo_bold "------------------------------------------------------------"
 	echo_bold "PACKAGE_GIT_URL:      $PACKAGE_GIT_URL"
 	echo_bold "PACKAGE_GIT_BRANCH:   $PACKAGE_GIT_BRANCH"
-	echo_bold "PACKAGE_VERSION:      $PACKAGE_VERSION"
 	echo_bold "PACKAGE_REVISION:     $PACKAGE_REVISION"
 	echo_bold "------------------------------------------------------------"
 }
@@ -984,8 +960,22 @@ function push_to_remote() {
 # If no changelog file exists, source package name can be passed in first arg.
 #
 function set_changelog() {
-	check_env PACKAGE_VERSION PACKAGE_REVISION
+	check_env PACKAGE_REVISION
 	local src_package="${1:-$PACKAGE}"
+
+	#
+	# If PACKAGE_VERSION hasn't been set already, then retrieve it from
+	# The changelog file. If the changelog file doesn't exist, which
+	# could be the case for in-house packages where we do not care about
+	# the version, then default to "1.0.0".
+	#
+	if [[ -z "$PACKAGE_VERSION" ]]; then
+		if [[ -f debian/changelog ]]; then
+			PACKAGE_VERSION="$(logmust dpkg-parsechangelog -S Version | awk -F'-' '{print $1}')"
+		else
+			PACKAGE_VERSION=1.0.0
+		fi
+	fi
 
 	logmust export DEBEMAIL="Delphix Engineering <eng@delphix.com>"
 	if [[ -f debian/changelog ]]; then

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bpftrace.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 PACKAGE_DEPENDENCIES="bcc"
 
 UPSTREAM_GIT_URL="https://github.com/iovisor/bpftrace.git"

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/linux-dlpx-pkgs.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/cloud-init/config.sh
+++ b/packages/cloud-init/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/cloud-init.git"
-# Note: we get the package version programatically in build()
 
 UPSTREAM_SOURCE_PACKAGE=cloud-init
 
@@ -31,10 +30,6 @@ function checkstyle() {
 }
 
 function build() {
-	logmust cd "$WORKDIR/repo"
-	if [[ -z "$PACKAGE_VERSION" ]]; then
-		logmust eval PACKAGE_VERSION="$(python3 tools/read-version)"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/connstat.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 PACKAGE_DEPENDENCIES="@linux-kernel"
 
 function prepare() {

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/linux-3rd-party-pkgs.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 SKIP_COPYRIGHTS_CHECK=true
 
 function build() {

--- a/packages/delphix-kernel/config.sh
+++ b/packages/delphix-kernel/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-kernel.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 PACKAGE_DEPENDENCIES="@linux-kernel"
 
 function prepare() {

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -17,13 +17,12 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function build() {
 	logmust cd "$WORKDIR/repo"
 	logmust ansible-playbook bootstrap/playbook.yml
 	logmust ./scripts/docker-run.sh make packages \
-		VERSION="$PACKAGE_VERSION-$PACKAGE_REVISION"
+		VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/docker-python-image/config.sh
+++ b/packages/docker-python-image/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/docker-python-image.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function prepare() {
 	logmust install_build_deps_from_control_file

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/drgn.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 PACKAGE_DEPENDENCIES="libkdumpfile"
 
 UPSTREAM_GIT_URL="https://github.com/osandov/drgn.git"

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -37,11 +37,6 @@ function prepare() {
 # Build the package.
 #
 function build() {
-	logmust cd "$WORKDIR/repo"
-	if [[ -z $PACKAGE_VERSION ]]; then
-		logmust eval PACKAGE_VERSION="$(dpkg-parsechangelog -S Version |
-			awk -F'-' '{print $1}')"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 
 UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
 UPSTREAM_GIT_BRANCH="tip"

--- a/packages/make-jpkg/config.sh
+++ b/packages/make-jpkg/config.sh
@@ -17,20 +17,11 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/make-jpkg.git"
-# Note we auto-detect version in build()
 
 UPSTREAM_GIT_URL=https://salsa.debian.org/java-team/java-package.git
 UPSTREAM_GIT_BRANCH=master
 
 function build() {
-	# Auto-detect version from upstream.
-	# Make sure it is a base version, without revision.
-	logmust cd "$WORKDIR/repo"
-	PACKAGE_VERSION=$(dpkg-parsechangelog --show-field Version)
-	if [[ "$PACKAGE_VERSION" == *-* ]]; then
-		die "Bad package version '$PACKAGE_VERSION': should not contain '-'"
-	fi
-
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/makedumpfile.git"
-# Note: we get the package version programatically in our build() hook
 
 UPSTREAM_SOURCE_PACKAGE="makedumpfile"
 
@@ -26,10 +25,6 @@ function prepare() {
 }
 
 function build() {
-	logmust cd "$WORKDIR/repo"
-	if [[ -z "$PACKAGE_VERSION" ]]; then
-		logmust eval PACKAGE_VERSION="1:$(grep '^VERSION=' Makefile | cut -d "=" -f 2)"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/nfs-utils/config.sh
+++ b/packages/nfs-utils/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/nfs-utils.git"
-# Note: we get the package version programatically in build()
 
 UPSTREAM_SOURCE_PACKAGE=nfs-utils
 
@@ -26,11 +25,6 @@ function prepare() {
 }
 
 function build() {
-	logmust cd "$WORKDIR/repo"
-	if [[ -z "$PACKAGE_VERSION" ]]; then
-		vers="$(dpkg-parsechangelog --show-field Version)"
-		logmust eval PACKAGE_VERSION="$vers"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/performance-diagnostics/config.sh
+++ b/packages/performance-diagnostics/config.sh
@@ -18,7 +18,6 @@
 #
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/performance-diagnostics.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function prepare() {
 	logmust install_build_deps_from_control_file

--- a/packages/python-rtslib-fb/config.sh
+++ b/packages/python-rtslib-fb/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/python-rtslib-fb.git"
-# Note: we get the package version programatically in build()
 
 UPSTREAM_SOURCE_PACKAGE=python-rtslib-fb
 
@@ -26,10 +25,6 @@ function prepare() {
 }
 
 function build() {
-	if [[ -z "$PACKAGE_VERSION" ]]; then
-		logmust cd "$WORKDIR/repo"
-		logmust eval PACKAGE_VERSION="$(./setup.py --version)"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/recovery-environment.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 PACKAGE_DEPENDENCIES="zfs"
 
 function prepare() {

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/savedump.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/sdb/config.sh
+++ b/packages/sdb/config.sh
@@ -17,7 +17,6 @@
 
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/sdb.git"
-DEFAULT_PACKAGE_VERSION=1.0.0
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/targetcli-fb/config.sh
+++ b/packages/targetcli-fb/config.sh
@@ -18,7 +18,6 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/targetcli-fb.git"
 PACKAGE_DEPENDENCIES="python-rtslib-fb"
-# Note: we get the package version programatically in build()
 
 UPSTREAM_SOURCE_PACKAGE=targetcli-fb
 
@@ -28,11 +27,6 @@ function prepare() {
 }
 
 function build() {
-	if [[ -z "$PACKAGE_VERSION" ]]; then
-		logmust cd "$WORKDIR/repo"
-		logmust eval PACKAGE_VERSION="$(./setup.py --version |
-			sed 's/fb//')"
-	fi
 	logmust dpkg_buildpackage_default
 }
 

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/omnibus-td-agent.git"
-# Note: we get the package version programatically in build()
 
 UPSTREAM_GIT_URL=https://github.com/treasure-data/omnibus-td-agent.git
 UPSTREAM_GIT_BRANCH=master

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/zfs.git"
-DEFAULT_PACKAGE_VERSION="0.8.0"
 PACKAGE_DEPENDENCIES="@linux-kernel"
 
 UPSTREAM_GIT_URL="https://github.com/zfsonlinux/zfs.git"
@@ -86,10 +85,11 @@ function build() {
 	# in /sys/module/zfs/version. The version is set by modifying the META
 	# file.
 	#
+	PACKAGE_VERSION="$(grep -E '^Version:' META | awk '{print $2}')"
+	[[ -n "$PACKAGE_VERSION" ]] || die "Failed to retrieve package version"
+
 	local hash
 	logmust eval hash="$(git rev-parse --short HEAD)"
-	logmust sed -i "s/^Version:.*/Version:      $PACKAGE_VERSION/" META ||
-		die "failed to set version"
 	logmust sed -i "s/^Release:.*/Release:      $PACKAGE_REVISION-$hash/" \
 		META || die "failed to set version"
 	logmust set_changelog

--- a/template/config.sh
+++ b/template/config.sh
@@ -26,17 +26,6 @@
 DEFAULT_PACKAGE_GIT_URL="https://example.com/my-package-repository.git"
 
 #
-# A version for the package must be provided in DEFAULT_PACKAGE_VERSION.
-# For an original Delphix package, the value for the version is not important,
-# so you can set it to anything (e.g. 1.0.0).
-# For a third-party package, this should match the version of the upstream
-# package. Note that an alternative is to leave DEFAULT_PACKAGE_VERSION
-# undefined and to programatically obtain PACKAGE_VERSION from the package's
-# source code.
-#
-#DEFAULT_PACKAGE_VERSION=1.0.0
-
-#
 # If you are adding a third-package from an upstream git project, uncomment
 # and fill the two lines below.
 #


### PR DESCRIPTION
This code cleanup mainly gets rid of the DEFAULT_PACKAGE_VERSION parameter, but also other parameters which aren't being used.

## Testing
- Rebuild all packages: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-packages/job/pre-push/420/
- ab-pre-push (including upgrade): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/4921/