### PR TITLE
TOOL-11187 leverage linux-pkg to build delphix-masking package (#141)

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -18,6 +18,7 @@ grub2
 libkdumpfile
 make-jpkg
 makedumpfile
+masking
 misc-debs
 nfs-utils
 performance-diagnostics


### PR DESCRIPTION
`build-packages` is [here](http://collins.d.delphix.com:29627/job/devops-gate/job/master/job/linux-pkg/job/6.0/job/stage/job/build-packages/job/post-push/8/)
`build-package` is [here](http://collins.d.delphix.com:29627/job/devops-gate/job/master/job/linux-pkg/job/6.0/job/stage/job/build-package/job/masking/job/post-push/1/)