### PR TITLE
DLPX-74479 Create a separate host-jdks package for all files under /u…

### DIFF
--- a/packages/host-jdks/config.sh
+++ b/packages/host-jdks/config.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Copyright 2021 Delphix
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/host-jdks.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
…sr/share/host-jdks


# Context:
This change is part of CP-4190 (Self-service hotfix and automation - Phase I)
We want to separate host-jdks which are currently part of delphix-virtualization debian package into a separate debian package to reduce size of the hotfix build. 

# Problem:

Currently the size of all host jdk files under /opt/delphix/host is close to 1GB. We don't want to build JDKs every time a new hotfix build is generated. Thus separating these files into a separate package seems logical. 

delphix@ip-10-110-202-68:~$ sudo find /opt/delphix/host -type f -size +10M -exec du -h {} \; | sort -n
45M	/opt/delphix/host/windows/DelphixConnectorInstaller.exe
75M	/opt/delphix/host/jdk/linux_x86/jdk1.8_172/jdk.tar.gz
96M	/opt/delphix/host/jdk/linux_ppc64le/jdk1.8/jdk.tar.gz
96M	/opt/delphix/host/jdk/windows_x86/jdk1.8/jdk.zip
99M	/opt/delphix/host/jdk/linux_x86/jdk1.8/jdk.tar.gz
101M	/opt/delphix/host/jdk/sunos_x86/jdk1.8/jdk.tar.gz
104M	/opt/delphix/host/jdk/sunos_sparc/jdk1.8/jdk.tar.gz
115M	/opt/delphix/host/jdk/hpux_ia64/jdk1.8/jdk.tar.gz
145M	/opt/delphix/host/jdk/aix_powerpc/jdk1.8/jdk.tar.gz



# Solution:

Generate an independent host-jdks debian package. 


# Testing:

 http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/custom/job/build-packages/job/custom/71/console (PASSED)


# Implementation:
Created a new package for host-jdks when unpacked the JDK files will be located at /usr/share/host-jdks


# Notes To Reviewers:
This is my first linux-pkg PR :) I am not sure about the order of how these changes should go in. I am willing to split the change into multiple reviews if needed. 


# Deployment Plan:
This change needs to go in along with the corresponding app-gate change, https://gitlab.delphix.com/aditya.joshi/dlpx-app-gate/commit/3ebf4b64af50d5145d151ab1b52484eb6bb334eb

<!--
# Future work:
A description of what follow up work is explicitly not being done in
this change.
-->
<!--
# Bonus:
A description of extra problems you've solved in this change. Did you
reformat an unrelated docstring? Point it out here
-->
