### PR TITLE
CP-4971 host-jdks config.sh

### DIFF
--- a/packages/host-jdks/config.sh
+++ b/packages/host-jdks/config.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2021 Delphix
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/host-jdks.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
# Context:
Part 1: Splitting the review for DLPX-74479: host-jdks config.sh
Use the debian directory code from https://github.com/delphix/host-jdks 

# Testing:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/custom/job/build-package/job/custom/64/
