### PR TITLE
TOOL-11608 Missing hostchecker2 "tars" sub-directory from virtualization build

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -87,7 +87,7 @@ function build() {
 	#
 	logmust cd "$WORKDIR/repo/appliance"
 	logmust rsync -av packaging/build/distributions/ "$WORKDIR/artifacts/"
-	logmust cp -vr \
+	logmust rsync -av \
 		bin/out/common/com.delphix.common/uem/tars \
 		"$WORKDIR/artifacts/hostchecker2"
 	logmust cp -v \


### PR DESCRIPTION
Consumers of the virtualization build, expect hostchecker tarballs to reside within the `hostchecker2/tars` sub-directory, but currently they're being placed directly in the `hostchecker2` directory. For example, looking at the S3 output location, I see this:
```
$ aws s3 ls s3://dev-de-images/builds/jenkins-selfservice/devops-gate/master/linux-pkg/master/build-package/virtualization/pre-push/127/hostchecker2/
2021-05-13 19:16:08  171796480 hostchecker_aix_powerpc.tar
2021-05-13 19:16:08  139868160 hostchecker_hpux_ia64.tar
2021-05-13 19:16:08  122931200 hostchecker_linux_x86.tar
2021-05-13 19:16:08  128645120 hostchecker_sunos_sparc.tar
2021-05-13 19:16:09  124794880 hostchecker_sunos_x86.tar
```

As a result, consumers of these files do not work properly; for example, in the `appliance-build-stage0` job logs I can see this:

```
13:41:34  + find '*' -type f -print0
13:41:34  + xargs -0 sha256sum
13:41:34  find: ‘*’: No such file or directory
13:41:34  [Pipeline] sh
13:41:34  + find '*' -type f -print0
13:41:34  + xargs -0 md5sum
13:41:34  find: ‘*’: No such file or directory
```

Further, the logic we use to generate and publish a release of our product depends on these files being within that "tars" sub-directory. As we attempted to release 6.0.8.0, we noticed these files were not where they were expected to be, which caused issues publishing our release artifacts.


With this change, these files will properly be stored in the `tars` subdirectory; for example:
```
$ aws s3 ls s3://dev-de-images/builds/jenkins-selfservice/devops-gate/master/linux-pkg/master/build-package/virtualization/pre-push/128/hostchecker2/tars
                           PRE tars/
$ aws s3 ls s3://dev-de-images/builds/jenkins-selfservice/devops-gate/master/linux-pkg/master/build-package/virtualization/pre-push/128/hostchecker2/tars/
2021-05-13 21:38:08  171796480 hostchecker_aix_powerpc.tar
2021-05-13 21:38:10  139868160 hostchecker_hpux_ia64.tar
2021-05-13 21:38:11  122931200 hostchecker_linux_x86.tar
2021-05-13 21:38:12  128645120 hostchecker_sunos_sparc.tar
2021-05-13 21:38:13  124794880 hostchecker_sunos_x86.tar
```