### PR TITLE
CP-5111 [Backport of CP-4543 to 6.0.9.0]

### DIFF
--- a/packages/docker-python-image/config.sh
+++ b/packages/docker-python-image/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/docker-python-image.git"
+DEFAULT_PACKAGE_VERSION="1.0.0"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
 CP-5111 [Backport of CP-4543 to 6.0.9.0] Write package to pull down Base Docker image of python:2.7.18-slim and save it to disk
