### PR TITLE
CP-5111 [Backport of CP-4543 to 6.0.9.0] main.pkgs update follow on

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -12,6 +12,7 @@ crypt-blowfish
 delphix-platform
 delphix-sso-app
 drgn
+docker-python-image
 gdb-python
 grub2
 libkdumpfile


### PR DESCRIPTION
running git-ab-pre-push with linux-pkg pointing to these changes:

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5295/

This does have some other appgate backport changes that requires the linux pkg changes.

In http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/6.0/job/stage/job/combine-packages/job/pre-push/153/console we see:
```
15:41:01  docker-python-image: s3://snapshot-de-images/builds/jenkins-ops/devops-gate/master/linux-pkg/6.0/stage/build-package/docker-python-image/post-push/2
```