### PR TITLE
zfs_object_agent build requires cargo, rustc

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -29,6 +29,7 @@ function prepare() {
 		autogen \
 		autotools-dev \
 		build-essential \
+		cargo \
 		debhelper \
 		devscripts \
 		dh-autoreconf \
@@ -48,8 +49,10 @@ function prepare() {
 		lsb-release \
 		lsscsi \
 		parted \
+		pkg-config \
 		po-debconf \
 		python3 \
+		rustc \
 		uuid-dev \
 		zlib1g-dev
 	logmust install_kernel_headers


### PR DESCRIPTION
zfs-object-agent is written in rust. We need to install rust devtools on the bootstrap VM before we build the ZFS packages. This change accomplishes that.

Successful build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-package/job/zfs/job/pre-push/123/console

Note: We had done this earlier for the delphix appliance.
https://github.com/delphix/appliance-build/pull/544
