### PR TITLE
CP-5081 [Backport of CP-4898 to 6.0.9.0] Write gradle task to download grpcio and generate grpc files

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -37,7 +37,8 @@ function prepare() {
 		libxcb-shm0 \
 		python-jira \
 		python-requests \
-		rsync
+		rsync \
+		virtualenv
 
 	logmust install_pkgs \
 		"$DEPDIR"/adoptopenjdk/*.deb \


### PR DESCRIPTION
Same as the original diff. we need to get the virtualization package to have virtualenv installed.

this isn't the best way to do it because the virtualenv here is a very old version.

http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5319/
^ this was built with some other appgate backport changes.