### PR TITLE
Add pahole utility needed for BTF generation in our kernels

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -39,7 +39,8 @@ function kernel_prepare() {
 	logmust install_pkgs \
 		equivs \
 		devscripts \
-		kernel-wedge
+		kernel-wedge \
+		dwarves # installs pahole(1) needed for BTF
 }
 
 #


### PR DESCRIPTION
## Motivation

`bpftrace` has had BTF support for a while (ref: https://github.com/iovisor/bpftrace/blob/master/docs/reference_guide.md#btf-support). We currently have in-place a few hacks to include ZFS (and other?) headers in our bpftrace package so we can use the type information on our scripts. If we had BTF info on our kernels we would no longer need those hacks for ZFS (and any other kernel modules really).

## This Patch

This PR includes the `pahole(1)` utilty that is part of the `dwarves` package from Canonical. This utility will be automatically used by our kernel builds when we enable the `CONFIG_DEBUG_INFO_BTF` config flag on our kernels, to generate BTF info.

## Testing

TBA