### PR TITLE
TOOL-6432 virtualization package build fails with out of memory

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -45,6 +45,16 @@ function prepare() {
 		"$DEPDIR"/crypt-blowfish/*.deb \
 		"$DEPDIR"/host-jdks/*.deb \
 		"$DEPDIR"/misc-debs/unzip_6.0-21ubuntu1_amd64.deb
+
+	#
+	# The virtualization build may fail due to OOM issues, thus we
+	# add a swap device to account for low memory situations. For
+	# more information, see TOOL-6432.
+	#
+	logmust dd if=/dev/zero of=/swapfile bs=1G count=1
+	logmust chmod 0600 /swapfile
+	logmust mkswap /swapfile
+	logmust swapon /swapfile
 }
 
 function build() {


### PR DESCRIPTION
I've recently seen OOM events and failed builds when trying to build the virtualization package via our Jenkins automation; e.g. see [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/custom/job/build-package/job/custom/83/) and [here](http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/custom/job/build-package/job/custom/84/). I believe the issue is that in the context of #144 we stopped using a swap device when building the virtualization package; this change re-introduces the use of a swap device.