### PR TITLE
TOOL-11757 linux-pkg: use build dependencies list stored in virtualization package repository

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -494,12 +494,13 @@ function list_all_packages() {
 }
 
 #
-# Read a package-list file and return listed packages in _RET_LIST.
+# Read a new-line separated list from a file, removing extra whitespace
+# and comments. Return items in _RET_LIST.
 #
-function read_package_list() {
+function read_list() {
 	local file="$1"
 
-	local pkg
+	local item
 	local line
 
 	_RET_LIST=()
@@ -508,13 +509,26 @@ function read_package_list() {
 
 	while read -r line; do
 		# trim whitespace
-		pkg=$(echo "$line" | tr -d '[:space:]')
-		[[ -z "$pkg" ]] && continue
+		item=$(echo "$line" | tr -d '[:space:]')
+		[[ -z "$item" ]] && continue
 		# ignore comments
-		[[ ${pkg:0:1} == "#" ]] && continue
+		[[ ${item:0:1} == "#" ]] && continue
+		_RET_LIST+=("$item")
+	done <"$file" || die "Failed to read list: $file"
+}
+
+#
+# Read a package-list file and return listed packages in _RET_LIST.
+#
+function read_package_list() {
+	local file="$1"
+
+	local pkg
+
+	logmust read_list "$file"
+	for pkg in "${_RET_LIST[@]}"; do
 		check_package_exists "$pkg"
-		_RET_LIST+=("$pkg")
-	done <"$file" || die "Failed to read package list: $file"
+	done
 }
 
 #

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -20,25 +20,8 @@ DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/app/dlpx-app-gate.git"
 PACKAGE_DEPENDENCIES="adoptopenjdk crypt-blowfish host-jdks misc-debs"
 
 function prepare() {
-	logmust install_pkgs \
-		ant \
-		gcc \
-		libcairo2 \
-		libcurl4-openssl-dev \
-		libjbig0 \
-		libnss3-dev \
-		libnss3-dbg \
-		libnss3-tools \
-		libpam0g-dev \
-		libpixman-1-0 \
-		libssl-dev \
-		libtiff5 \
-		libxcb-render0 \
-		libxcb-shm0 \
-		python-jira \
-		python-requests \
-		rsync \
-		virtualenv
+	logmust read_list "$WORKDIR/repo/appliance/packaging/build-dependencies"
+	logmust install_pkgs "${_RET_LIST[@]}"
 
 	logmust install_pkgs \
 		"$DEPDIR"/adoptopenjdk/*.deb \


### PR DESCRIPTION
This changes linux-pkg's recipe to build the virtualization package to use build dependencies list created in TOOL-11756 (pending review: http://reviews.delphix.com/r/70289/)

## Testing
See testing section in http://reviews.delphix.com/r/70289/