### PR TITLE
TOOL-11734 linux-pkg should use install_build_deps_from_control_file whenever possible

### DIFF
--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -19,10 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils \
-		python3.6-dev
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -19,23 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
 
 function prepare() {
-	logmust install_pkgs \
-		autoconf \
-		automake \
-		bison \
-		flex \
-		git \
-		liblzo2-dev \
-		libmpfr-dev \
-		libsnappy1v5 \
-		libtool \
-		pkg-config \
-		python3-distutils \
-		python3-future \
-		python3-pyelftools \
-		python3.6-dev \
-		texinfo \
-		zlib1g-dev
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -19,9 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/savedump.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/sdb/config.sh
+++ b/packages/sdb/config.sh
@@ -19,9 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/sdb.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils
+	logmust install_build_deps_from_control_file
 }
 
 function build() {


### PR DESCRIPTION

## Testing
git-ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5515/