### PR TITLE
TOOL-11892 Bulk modify of shebang lines to use /usr/bin/env

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2021 Delphix
 #

--- a/checkupdates.sh
+++ b/checkupdates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/cloud-init/config.sh
+++ b/packages/cloud-init/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2019 Delphix
 #

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/delphix-kernel/config.sh
+++ b/packages/delphix-kernel/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/delphix-sso-app/config.sh
+++ b/packages/delphix-sso-app/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/docker-python-image/config.sh
+++ b/packages/docker-python-image/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.archive.sh
+++ b/packages/linux-kernel-aws/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.delphix.sh
+++ b/packages/linux-kernel-aws/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.prebuilt.sh
+++ b/packages/linux-kernel-aws/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.sh
+++ b/packages/linux-kernel-aws/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.archive.sh
+++ b/packages/linux-kernel-azure/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.delphix.sh
+++ b/packages/linux-kernel-azure/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.prebuilt.sh
+++ b/packages/linux-kernel-azure/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.sh
+++ b/packages/linux-kernel-azure/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.archive.sh
+++ b/packages/linux-kernel-gcp/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.delphix.sh
+++ b/packages/linux-kernel-gcp/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.prebuilt.sh
+++ b/packages/linux-kernel-gcp/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.sh
+++ b/packages/linux-kernel-gcp/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.archive.sh
+++ b/packages/linux-kernel-generic/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.delphix.sh
+++ b/packages/linux-kernel-generic/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.prebuilt.sh
+++ b/packages/linux-kernel-generic/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.sh
+++ b/packages/linux-kernel-generic/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.archive.sh
+++ b/packages/linux-kernel-oracle/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.delphix.sh
+++ b/packages/linux-kernel-oracle/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.prebuilt.sh
+++ b/packages/linux-kernel-oracle/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.sh
+++ b/packages/linux-kernel-oracle/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/make-jpkg/config.sh
+++ b/packages/make-jpkg/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/nfs-utils/config.sh
+++ b/packages/nfs-utils/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/performance-diagnostics/config.sh
+++ b/packages/performance-diagnostics/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/ptools/config.sh
+++ b/packages/ptools/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2019 Delphix
 #

--- a/packages/python-rtslib-fb/config.sh
+++ b/packages/python-rtslib-fb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Delphix
 #

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/sdb/config.sh
+++ b/packages/sdb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/targetcli-fb/config.sh
+++ b/packages/targetcli-fb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/push-merge.sh
+++ b/push-merge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/query-packages.sh
+++ b/query-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/sync-with-upstream.sh
+++ b/sync-with-upstream.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/template/config.sh
+++ b/template/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Delphix
 #


### PR DESCRIPTION
## Problem

We hardcode the shebang of our bash scripts to use `/bin/bash`. There
are two problems with this.
 - Using that as the shebang line makes these bash scripts
   non-portable in the cases where `/bin/bash` does not exist.
 - By using that as the shebang line we do not allow users to change
   what version of `bash` they use by modifying their `PATH`.

## Solution

Use whichever version of `bash` is first on their PATH by using
`/usr/bin/env bash` instead of `/bin/bash`.

## Implementation

I greped for `#!/bin/bash` and replaced that with `#!/usr/bin/env
bash`. We never passed extra flags such as `-e` to the shebang so no
futher changes are needed.

## Testing

None