### PR TITLE
zfs_object_agent build requires cargo (#169)

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -29,6 +29,7 @@ function prepare() {
 		autogen \
 		autotools-dev \
 		build-essential \
+		cargo \
 		debhelper \
 		devscripts \
 		dh-autoreconf \
@@ -48,8 +49,10 @@ function prepare() {
 		lsb-release \
 		lsscsi \
 		parted \
+		pkg-config \
 		po-debconf \
 		python3 \
+		rustc \
 		uuid-dev \
 		zlib1g-dev
 	logmust install_kernel_headers


### PR DESCRIPTION
Backport to 6.0/stage:
```
commit 9148daf3f5ddd4929da3ec43e65db49a91bba5e5 
Author: Manoj Joseph <manoj.joseph@delphix.com>
Date:   Tue May 18 10:29:26 2021 -0700

    zfs_object_agent build requires cargo (#169)

```
linux-pkg build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/6.0/job/stage/job/build-package/job/zfs/job/pre-push/57/console PASS

appliance-build: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5787/console BUILD SUCCESSFUL
