### PR TITLE
Merge master into 6.0/stage

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2021 Delphix
 #

--- a/checkupdates.sh
+++ b/checkupdates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/bpftrace/config.sh
+++ b/packages/bpftrace/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/cloud-init/config.sh
+++ b/packages/cloud-init/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2019 Delphix
 #

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #
@@ -19,10 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils \
-		python3.6-dev
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/delphix-kernel/config.sh
+++ b/packages/delphix-kernel/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/delphix-sso-app/config.sh
+++ b/packages/delphix-sso-app/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/docker-python-image/config.sh
+++ b/packages/docker-python-image/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/docker-python-image.git"
-DEFAULT_PACKAGE_VERSION="1.0.0"
 
 function prepare() {
 	logmust install_build_deps_from_control_file

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #
@@ -20,7 +20,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/drgn.git"
 PACKAGE_DEPENDENCIES="libkdumpfile"
 
 UPSTREAM_GIT_URL="https://github.com/osandov/drgn.git"
-UPSTREAM_GIT_BRANCH="master"
+UPSTREAM_GIT_BRANCH="main"
 
 function prepare() {
 	#

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #
@@ -19,23 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
 
 function prepare() {
-	logmust install_pkgs \
-		autoconf \
-		automake \
-		bison \
-		flex \
-		git \
-		liblzo2-dev \
-		libmpfr-dev \
-		libsnappy1v5 \
-		libtool \
-		pkg-config \
-		python3-distutils \
-		python3-future \
-		python3-pyelftools \
-		python3.6-dev \
-		texinfo \
-		zlib1g-dev
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/host-jdks/config.sh
+++ b/packages/host-jdks/config.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Copyright 2021 Delphix
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Copyright 2021 Delphix
 #

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.archive.sh
+++ b/packages/linux-kernel-aws/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.delphix.sh
+++ b/packages/linux-kernel-aws/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.prebuilt.sh
+++ b/packages/linux-kernel-aws/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-aws/config.sh
+++ b/packages/linux-kernel-aws/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.archive.sh
+++ b/packages/linux-kernel-azure/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.delphix.sh
+++ b/packages/linux-kernel-azure/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.prebuilt.sh
+++ b/packages/linux-kernel-azure/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-azure/config.sh
+++ b/packages/linux-kernel-azure/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.archive.sh
+++ b/packages/linux-kernel-gcp/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.delphix.sh
+++ b/packages/linux-kernel-gcp/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.prebuilt.sh
+++ b/packages/linux-kernel-gcp/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-gcp/config.sh
+++ b/packages/linux-kernel-gcp/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.archive.sh
+++ b/packages/linux-kernel-generic/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.delphix.sh
+++ b/packages/linux-kernel-generic/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.prebuilt.sh
+++ b/packages/linux-kernel-generic/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-generic/config.sh
+++ b/packages/linux-kernel-generic/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.archive.sh
+++ b/packages/linux-kernel-oracle/config.archive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.delphix.sh
+++ b/packages/linux-kernel-oracle/config.delphix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.prebuilt.sh
+++ b/packages/linux-kernel-oracle/config.prebuilt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/linux-kernel-oracle/config.sh
+++ b/packages/linux-kernel-oracle/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/make-jpkg/config.sh
+++ b/packages/make-jpkg/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/makedumpfile/config.sh
+++ b/packages/makedumpfile/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #

--- a/packages/nfs-utils/config.sh
+++ b/packages/nfs-utils/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/performance-diagnostics/config.sh
+++ b/packages/performance-diagnostics/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/ptools/config.sh
+++ b/packages/ptools/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2019 Delphix
 #

--- a/packages/python-rtslib-fb/config.sh
+++ b/packages/python-rtslib-fb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Delphix
 #

--- a/packages/recovery-environment/config.sh
+++ b/packages/recovery-environment/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/packages/savedump/config.sh
+++ b/packages/savedump/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #
@@ -19,9 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/savedump.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/sdb/config.sh
+++ b/packages/sdb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #
@@ -19,9 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/sdb.git"
 
 function prepare() {
-	logmust install_pkgs \
-		git \
-		python3-distutils
+	logmust install_build_deps_from_control_file
 }
 
 function build() {

--- a/packages/targetcli-fb/config.sh
+++ b/packages/targetcli-fb/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/packages/td-agent/config.sh
+++ b/packages/td-agent/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019 Delphix
 #

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 Delphix
 #
@@ -20,25 +20,8 @@ DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/app/dlpx-app-gate.git"
 PACKAGE_DEPENDENCIES="adoptopenjdk crypt-blowfish host-jdks misc-debs"
 
 function prepare() {
-	logmust install_pkgs \
-		ant \
-		gcc \
-		libcairo2 \
-		libcurl4-openssl-dev \
-		libjbig0 \
-		libnss3-dev \
-		libnss3-dbg \
-		libnss3-tools \
-		libpam0g-dev \
-		libpixman-1-0 \
-		libssl-dev \
-		libtiff5 \
-		libxcb-render0 \
-		libxcb-shm0 \
-		python-jira \
-		python-requests \
-		rsync \
-		virtualenv
+	logmust read_list "$WORKDIR/repo/appliance/packaging/build-dependencies"
+	logmust install_pkgs "${_RET_LIST[@]}"
 
 	logmust install_pkgs \
 		"$DEPDIR"/adoptopenjdk/*.deb \

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2019, 2020 Delphix
 #

--- a/push-merge.sh
+++ b/push-merge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/query-packages.sh
+++ b/query-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018, 2020 Delphix
 #

--- a/sync-with-upstream.sh
+++ b/sync-with-upstream.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2020 Delphix
 #

--- a/template/config.sh
+++ b/template/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Delphix
 #


### PR DESCRIPTION
This backports the following changes:
- Add comment to explain use of "--allow-downgrades" (#150)
- change drgn upstream repo to main (#161)
- TOOL-11734 linux-pkg should use install_build_deps_from_control_file whenever possible (#177)
- TOOL-11757 linux-pkg: use build dependencies list stored in virtualization package repository (#175)
- TOOL-11815 linux-pkg: kernel sync-with-upstream logic sometimes fails to find expected tags upstream (#178)
- TOOL-11892 Bulk modify of shebang lines to use /usr/bin/env (#179)

The only difference remaining is the value of `branch.config`.

## Testing
ab-pre-push (rebuild all relevant packages): http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5819/parameters/