### PR TITLE
TOOL-12032 Enable linux-pkg to fetch from custom devops-gate branches

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2021 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ export SUPPORTED_KERNEL_FLAVORS="generic aws gcp azure oracle"
 # for testing purposes to use jenkins-ops.<developer> instead.
 #
 export JENKINS_OPS_DIR="${JENKINS_OPS_DIR:-jenkins-ops}"
+export S3_DEVOPS_BRANCH="${S3_DEVOPS_BRANCH:-master}"
 
 export UBUNTU_DISTRIBUTION="bionic"
 
@@ -659,7 +660,7 @@ function determine_dependencies_base_url() {
 		[[ -n "$suv" ]] || die "No artifacts found at $url"
 		DEPENDENCIES_BASE_URL="$url/$suv/input-artifacts/combined-packages/packages"
 	else
-		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/devops-gate/master/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
+		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/devops-gate/$S3_DEVOPS_BRANCH/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
 	fi
 
 	#


### PR DESCRIPTION
**Background:**

As part of [TOOL-11833](https://jira.delphix.com/browse/TOOL-11833) I am enabling the child Jenkins jobs to be kicked off from the same branch as the parent job.

**Problem:**

Due to the one to one relationship between the linux-pkg job paths and S3 URLs, enabling this functionality also requires plumbing in the devops-gate branch to the linux-pkg scripts.

**Solution:**

Enable the linux-pkg script to read a `S3_DEVOPS_BRANCH ` environment variable and use that variable.

**Testing:**

~~Ran `linux-pkg-build-package` on my ops dev instance on a development branch, notice how it looks in the correct path but package does not exist: http://collins.d.delphix.com:28565/job/devops-gate/job/t11833-branch-hardcode/job/linux-pkg/job/master/job/build-package/job/virtualization/job/post-push/3/console~~

~~Ran the same job on my ops dev instance on master branch with my development branch changes applied to it. The script looks in master branch but package does not exist: http://collins.d.delphix.com:28565/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-package/job/virtualization/job/post-push/2/console~~

Most up to date testing here: https://github.com/delphix/linux-pkg/pull/182#issuecomment-928447647

**Related items:**

- [TOOL-11833 Reviewboard diff](http://reviews.delphix.com/r/71923/)