### PR TITLE
DOSE-501 use newer version of rust to compile agent

### DIFF
--- a/packages/delphix-rust/config.sh
+++ b/packages/delphix-rust/config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-rust.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
```
$ ./buildpkg.sh delphix-rust
...
dpkg-deb: building package 'delphix-rust' in '../delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb'.
 dpkg-genbuildinfo --build=binary
 dpkg-genchanges --build=binary >../delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.changes
dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-source --after-build repo
dpkg-buildpackage: info: binary-only upload (no source included)
Running: cd /home/ubuntu/linux-pkg/packages/delphix-rust/tmp/
Running: mv ./delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb artifacts/
PACKAGE delphix-rust: STAGE build COMPLETED in 306 seconds

Running: cd /home/ubuntu/linux-pkg/packages/delphix-rust/tmp

PACKAGE delphix-rust: STAGE store_build_info STARTED
Running: store_build_info
Running: store_git_info
Running: pushd /home/ubuntu/linux-pkg/packages/delphix-rust/tmp/repo
~/linux-pkg/packages/delphix-rust/tmp/repo ~/linux-pkg/packages/delphix-rust/tmp
Running: popd
~/linux-pkg/packages/delphix-rust/tmp
PACKAGE delphix-rust: STAGE store_build_info COMPLETED in 0 seconds

Running: cd /home/ubuntu/linux-pkg/packages/delphix-rust/tmp

PACKAGE delphix-rust: STAGE post_build_checks STARTED
Running: post_build_checks
Running: dpkg-deb -c delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       799 2021-09-07 17:38 ./usr/share/doc/delphix-rust/copyright
PACKAGE delphix-rust: STAGE post_build_checks COMPLETED in 14 seconds

Success: Package delphix-rust has been built successfully.
Build products are in /home/ubuntu/linux-pkg/packages/delphix-rust/tmp/artifacts
```
```
$ dpkg -c packages/delphix-rust/tmp/artifacts/delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb | head
drwxr-xr-x root/root         0 2021-09-07 17:38 ./
drwxr-xr-x root/root         0 2021-09-07 17:38 ./usr/
drwxr-xr-x root/root         0 2021-09-07 17:38 ./usr/bin/
-rwxr-xr-x root/root  21963984 2021-09-07 17:38 ./usr/bin/cargo
-rwxr-xr-x root/root   3392128 2021-09-07 17:38 ./usr/bin/cargo-clippy
-rwxr-xr-x root/root   4556528 2021-09-07 17:38 ./usr/bin/cargo-fmt
-rwxr-xr-x root/root   8976864 2021-09-07 17:38 ./usr/bin/clippy-driver
-rwxr-xr-x root/root  36103448 2021-09-07 17:38 ./usr/bin/rls
-rwxr-xr-x root/root   5018184 2021-09-07 17:38 ./usr/bin/rust-demangler
-r
wxr-xr-x root/root       759 2021-09-07 17:38 ./usr/bin/rust-gdb
dpkg-deb: error: tar subprocess was killed by signal (Broken pipe)
```
```
$ dpkg -c packages/delphix-rust/tmp/artifacts/delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb | tail
-rw-r--r-- root/root      2142 2021-09-07 17:38 ./usr/share/man/man1/cargo-vendor.1.gz
-rw-r--r-- root/root      1664 2021-09-07 17:38 ./usr/share/man/man1/cargo-verify-project.1.gz
-rw-r--r-- root/root       340 2021-09-07 17:38 ./usr/share/man/man1/cargo-version.1.gz
-rw-r--r-- root/root      1646 2021-09-07 17:38 ./usr/share/man/man1/cargo-yank.1.gz
-rw-r--r-- root/root      2996 2021-09-07 17:38 ./usr/share/man/man1/cargo.1.gz
-rw-r--r-- root/root      3752 2021-09-07 17:38 ./usr/share/man/man1/rustc.1.gz
-rw-r--r-- root/root      1402 2021-09-07 17:38 ./usr/share/man/man1/rustdoc.1.gz
drwxr-xr-x root/root         0 2021-09-07 17:38 ./usr/share/zsh/
drwxr-xr-x root/root         0 2021-09-07 17:38 ./usr/share/zsh/site-functions/
-rw-r--r-- root/root     20681 2021-09-07 17:38 ./usr/share/zsh/site-functions/_cargo
```
```
$ dpkg -c packages/delphix-rust/tmp/artifacts/delphix-rust_1.0.0-delphix-2021.09.07.17_amd64.deb | wc -l
30357
```
```
$ sudo apt-get install ./delphix-rust_1.0.0-delphix-2021.09.07.18_amd64.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'delphix-rust' instead of './delphix-rust_1.0.0-delphix-2021.09.07.18_amd64.deb'
The following packages will be REMOVED:
  cargo rust-gdb rustc
The following NEW packages will be installed:
  delphix-rust
0 upgraded, 1 newly installed, 3 to remove and 0 not upgraded.
Need to get 0 B/147 MB of archives.
After this operation, 1,046 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 /export/home/delphix/delphix-rust_1.0.0-delphix-2021.09.07.18_amd64.deb delphix-rust amd64 1.0.0-delphix-2021.09.07.18 [147 MB]
(Reading database ... 154739 files and directories currently installed.)
Removing cargo (0.52.0-0ubuntu1~18.04.1) ...
Removing rust-gdb (1.51.0+dfsg1+llvm-1~exp3ubuntu1~18.04.1) ...
Removing rustc (1.51.0+dfsg1+llvm-1~exp3ubuntu1~18.04.1) ...
Selecting previously unselected package delphix-rust.
(Reading database ... 154664 files and directories currently installed.)
Preparing to unpack .../delphix-rust_1.0.0-delphix-2021.09.07.18_amd64.deb ...
Unpacking delphix-rust (1.0.0-delphix-2021.09.07.18) ...
Setting up delphix-rust (1.0.0-delphix-2021.09.07.18) ...
Processing triggers for man-db (2.8.3-2ubuntu0.1) ...
Processing triggers for libc-bin (2.27-3ubuntu1.4) ...
```
```
$ rustc --version
rustc 1.54.0 (a178d0322 2021-07-26)
```