### PR TITLE
TOOL-12213 linux-pkg: run setup.sh automatically when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,12 @@ This quick tutorial shows how to build the packages managed by this framework.
 You need a system that meets the requirements above. For Delphix developers, you
 should clone the `bootstrap-18-04` group on DCoA.
 
-### Step 2. Clone this repository and run the setup script
+### Step 2. Clone this repository
 
 Clone this repository on the build VM.
 
 ```
 git clone https://github.com/delphix/linux-pkg.git
-```
-
-Run the setup script. It only needs to be run once after cloning the VM.
-
-```
-cd linux-pkg
-./setup.sh
 ```
 
 ### Step 3. Build a package

--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -19,6 +19,7 @@ TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
 logmust check_running_system
+logmust run_setup_if_needed
 
 function usage() {
 	[[ $# != 0 ]] && echo "$(basename "$0"): $*"

--- a/checkupdates.sh
+++ b/checkupdates.sh
@@ -19,6 +19,7 @@ TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
 logmust check_running_system
+logmust run_setup_if_needed
 
 function usage() {
 	[[ $# != 0 ]] && echo "$(basename "$0"): $*"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -100,21 +100,34 @@ function logmust() {
 # scripts on their work system and changing its configuration.
 #
 function check_running_system() {
+	local msg
+
 	if [[ "$DISABLE_SYSTEM_CHECK" == "true" ]]; then
 		echo "WARNING: System check disabled."
 		return 0
 	fi
 
+	msg="Note that you can bypass this check by setting environment"
+	msg="${msg} variable DISABLE_SYSTEM_CHECK=true. Use this at your"
+	msg="${msg} own risk as running this command may modify your system."
+
 	if ! (command -v lsb_release >/dev/null &&
 		[[ $(lsb_release -cs) == "$UBUNTU_DISTRIBUTION" ]]); then
-		die "Script can only be ran on an ubuntu-${UBUNTU_DISTRIBUTION} system."
+		echo_error "Script can only be run on an ubuntu-${UBUNTU_DISTRIBUTION} system."
+		echo_bold "$msg"
+		exit 1
 	fi
 
 	if ! curl "http://169.254.169.254/latest/meta-datas" \
 		>/dev/null 2>&1; then
-		die "Not running in AWS, are you sure you are on the" \
+		echo_error "Not running in AWS, are you sure you are on the" \
 			"right system?"
+		echo_bold "$msg"
+		exit 1
 	fi
+
+	echo should not get here
+	exit 1
 }
 
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -118,6 +118,23 @@ function check_running_system() {
 }
 
 #
+# We need to have run setup.sh before running most linux-pkg commands.
+# This checks if setup has been run before. Note that if the system was
+# rebooted we want to rerun setup as cloud-init will reset apt sources on
+# boot.
+#
+function run_setup_if_needed() {
+	[[ -f /run/linux-pkg-setup ]] && return
+
+	check_env TOP
+	echo_bold "------------------------------------------------------------"
+	echo_bold "Running setup script"
+	echo_bold "------------------------------------------------------------"
+	logmust "$TOP/setup.sh"
+	echo_bold "------------------------------------------------------------"
+}
+
+#
 # Determine DEFAULT_GIT_BRANCH. If it is unset, default to the branch set in
 # branch.config.
 #

--- a/push-merge.sh
+++ b/push-merge.sh
@@ -19,6 +19,7 @@ TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
 logmust check_running_system
+logmust run_setup_if_needed
 
 function usage() {
 	[[ $# != 0 ]] && echo "$(basename "$0"): $*"

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,8 @@
 TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
+logmust check_running_system
+
 logmust determine_default_git_branch
 
 #
@@ -79,7 +81,6 @@ configure_apt_sources() {
 	logmust sudo apt-key add "$TOP/resources/delphix-secondary-mirror.key"
 }
 
-logmust check_running_system
 logmust configure_apt_sources
 logmust sudo apt-get update
 
@@ -113,3 +114,5 @@ logmust install_gcc8
 
 logmust git config --global user.email "eng@delphix.com"
 logmust git config --global user.name "Delphix Engineering"
+
+logmust sudo touch /run/linux-pkg-setup

--- a/sync-with-upstream.sh
+++ b/sync-with-upstream.sh
@@ -19,6 +19,7 @@ TOP="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 source "$TOP/lib/common.sh"
 
 logmust check_running_system
+logmust run_setup_if_needed
 
 function usage() {
 	[[ $# != 0 ]] && echo "$(basename "$0"): $*"


### PR DESCRIPTION
This is just a convenience feature to make the process simpler for developers to use linux-pkg.

## Testing
- Manually checked that setup script is run automatically the first time I run buildpkg.sh
- Manually checked that the setup script is run again after a reboot
- Sanity test to make sure build-package job still works: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-package/job/cloud-init/job/pre-push/31