### PR TITLE
TOOL-12355 linux-pkg: changes for Ubuntu 20.04

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -28,7 +28,7 @@ export SUPPORTED_KERNEL_FLAVORS="generic aws gcp azure oracle"
 export JENKINS_OPS_DIR="${JENKINS_OPS_DIR:-jenkins-ops}"
 export S3_DEVOPS_BRANCH="${S3_DEVOPS_BRANCH:-master}"
 
-export UBUNTU_DISTRIBUTION="bionic"
+export UBUNTU_DISTRIBUTION="focal"
 
 #
 # We currently support getting the linux kernel from 3 different sources:
@@ -1240,17 +1240,6 @@ function determine_target_kernels() {
 
 	echo_bold "Kernel versions to use to build modules:"
 	echo_bold "  $KERNEL_VERSIONS"
-}
-
-#
-# Install gcc 8, and make it the default
-#
-function install_gcc8() {
-	logmust install_pkgs gcc-8 g++-8
-	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
-		/usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
-	logmust sudo update-alternatives --install /usr/bin/gcc gcc \
-		/usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
 }
 
 #

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -17,7 +17,6 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
-PACKAGE_DEPENDENCIES="zfs"
 
 UPSTREAM_GIT_URL=https://git.launchpad.net/ubuntu/+source/grub2
 UPSTREAM_GIT_BRANCH="applied/ubuntu/${UBUNTU_DISTRIBUTION}-updates"
@@ -28,8 +27,6 @@ SKIP_COPYRIGHTS_CHECK=true
 # Install build dependencies for the package.
 #
 function prepare() {
-	# Install libzfs which is required to build grub
-	logmust install_pkgs "$DEPDIR"/zfs/{libnvpair1linux,libuutil1linux,libzfs2linux,libzpool2linux,libzfslinux-dev}_*.deb
 	logmust install_build_deps_from_control_file
 }
 

--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -20,7 +20,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
 PACKAGE_DEPENDENCIES="zfs"
 
 UPSTREAM_GIT_URL=https://git.launchpad.net/ubuntu/+source/grub2
-UPSTREAM_GIT_BRANCH=applied/ubuntu/bionic-updates
+UPSTREAM_GIT_BRANCH="applied/ubuntu/${UBUNTU_DISTRIBUTION}-updates"
 
 SKIP_COPYRIGHTS_CHECK=true
 

--- a/packages/linux-kernel-aws/config.delphix.sh
+++ b/packages/linux-kernel-aws/config.delphix.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/linux-kernel-aws.git"
 
-UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-aws/+git/bionic"
+UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-aws/+git/${UBUNTU_DISTRIBUTION}"
 # Note: UPSTREAM_GIT_BRANCH is not used here
 UPSTREAM_GIT_BRANCH="none"
 

--- a/packages/linux-kernel-azure/config.delphix.sh
+++ b/packages/linux-kernel-azure/config.delphix.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/linux-kernel-azure.git"
 
-UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/bionic"
+UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/${UBUNTU_DISTRIBUTION}"
 # Note: UPSTREAM_GIT_BRANCH is not used here
 UPSTREAM_GIT_BRANCH="none"
 

--- a/packages/linux-kernel-gcp/config.delphix.sh
+++ b/packages/linux-kernel-gcp/config.delphix.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/linux-kernel-gcp.git"
 
-UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-gcp/+git/bionic"
+UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-gcp/+git/${UBUNTU_DISTRIBUTION}"
 # Note: UPSTREAM_GIT_BRANCH is not used here
 UPSTREAM_GIT_BRANCH="none"
 

--- a/packages/linux-kernel-generic/config.delphix.sh
+++ b/packages/linux-kernel-generic/config.delphix.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/linux-kernel-generic.git"
 
-UPSTREAM_GIT_URL="https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/bionic"
+UPSTREAM_GIT_URL="https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/${UBUNTU_DISTRIBUTION}"
 # Note: UPSTREAM_GIT_BRANCH is not used here
 UPSTREAM_GIT_BRANCH="none"
 

--- a/packages/linux-kernel-oracle/config.delphix.sh
+++ b/packages/linux-kernel-oracle/config.delphix.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/linux-kernel-oracle.git"
 
-UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-oracle/+git/bionic"
+UPSTREAM_GIT_URL="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-oracle/+git/${UBUNTU_DISTRIBUTION}"
 # Note: UPSTREAM_GIT_BRANCH is not used here
 UPSTREAM_GIT_BRANCH="none"
 

--- a/setup.sh
+++ b/setup.sh
@@ -124,13 +124,6 @@ logmust install_pkgs \
 
 logmust install_shfmt
 
-#
-# Starting with kernel 5.4, gcc 7 can no longer compile kernel modules, so
-# install gcc 8
-# https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1849348
-#
-logmust install_gcc8
-
 logmust add_swap
 
 logmust git config --global user.email "eng@delphix.com"


### PR DESCRIPTION
Note: this will only be integrated when transitioning master to Ubuntu 20.04.

The changes are fairly basic:
- Don't install gcc8 anymore because Ubuntu 20.04 is using gcc9, which has all the fixes we needed.
- Update the upstream git url where appropriate
- Change UBUNTU_DISTRIBUTION to "focal", which is used in a few checks.

## Testing
Those changes have been soaking on the focal branch for a few months