### PR TITLE
JAIL-15 Post-push build for containerized masking

### DIFF
--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/masking/dms-core-gate.git"
+PACKAGE_DEPENDENCIES="adoptopenjdk"
+SKIP_COPYRIGHTS_CHECK=true
+
+function prepare() {
+	logmust install_pkgs "$DEPDIR"/adoptopenjdk/*.deb
+}
+
+function build() {
+	export JAVA_HOME
+	JAVA_HOME=$(cat "$DEPDIR/adoptopenjdk/JDK_PATH") ||
+		die "Failed to read $DEPDIR/adoptopenjdk/JDK_PATH"
+
+	logmust cd "$WORKDIR/repo"
+
+	logmust ./gradlew --no-daemon --stacktrace \
+		-Porg.gradle.configureondemand=false \
+		-PenvironmentName=linuxappliance \
+		:tools:docker:packageMaskingKubernetes
+
+	logmust cp -v tools/docker/build/masking-kubernetes.zip \
+		"$WORKDIR/artifacts/"
+}

--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -16,7 +16,16 @@
 #
 # shellcheck disable=SC2034
 
+#
+# This package has the same Git URL as the 'masking' package. In general we
+# probably don't want to have multiple packages with the same URL, since tools
+# like git-ab-pre-push expect that there is a 1:1 correspondence between
+# packages and URLs. However, this is OK in this case because git-ab-pre-push
+# only works with packages that are included in the appliance, which this one
+# isn't.
+#
 DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/masking/dms-core-gate.git"
+
 PACKAGE_DEPENDENCIES="adoptopenjdk"
 SKIP_COPYRIGHTS_CHECK=true
 


### PR DESCRIPTION
This adds a new package for a new flavor of the masking product. Although the output of this job will not be part of the appliance, we are using linux-pkg since linux-pkg provides a number of useful feature for building generic software, like automatically generated Jenkins jobs that will trigger on post-push, the creation of a build environment with the correct build dependencies installed, a simple way to upload output artifacts to S3, etc.

Because this package is not used by the appliance, we do not include it in any of the package lists, so that its build is not triggered by the `build-packages` job or by `git ab-pre-push`.

This new artifact could be built as part of the existing `masking` package by just adding another task to the Gradle invocation in that package's `config.sh`. However, since this package will be used independently, it seemed worth it to keep its build independent, even if it means spending a couple minutes compiling the dms-core-gate bits a second time.

**Testing**
[linux-pkg build job](http://collins.d.delphix.com:37977/job/devops-gate/job/master/job/linux-pkg/job/master/job/build-package/job/containerized-masking/job/pre-push/2/console)
Downloaded the zip file built by the job, loaded the images in the zip into k8s, and made sure the masking application started correctly.