### PR TITLE
GHM-159 Modify linux-pkg to point to GitHub version of repositories

### DIFF
--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -16,7 +16,7 @@
 #
 # shellcheck disable=SC2034
 
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/linux-dlpx-pkgs.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/challenge-response.git"
 
 function prepare() {
 	logmust install_pkgs \

--- a/packages/crash-python/config.sh
+++ b/packages/crash-python/config.sh
@@ -16,7 +16,7 @@
 #
 
 # shellcheck disable=SC2034
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/crash-python.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/crash-python.git"
 
 function prepare() {
 	logmust install_build_deps_from_control_file

--- a/packages/crypt-blowfish/config.sh
+++ b/packages/crypt-blowfish/config.sh
@@ -16,7 +16,7 @@
 #
 # shellcheck disable=SC2034
 
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/linux-3rd-party-pkgs.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/crypt-blowfish.git"
 SKIP_COPYRIGHTS_CHECK=true
 
 function build() {

--- a/packages/gdb-python/config.sh
+++ b/packages/gdb-python/config.sh
@@ -16,7 +16,7 @@
 #
 
 # shellcheck disable=SC2034
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/os-platform/gdb-python.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/gdb-python.git"
 
 function prepare() {
 	logmust install_build_deps_from_control_file


### PR DESCRIPTION
### Problem

We will be moving these repositories to GitHub, when we do we will
need to point all branches of the linux-pkg repository to these
migrated repos.

### Solution

Update the links

### Deployment Plan

This will be merged right after we perform the migration.

### Testing Done

Pending
