### PR TITLE
TOOL-12470 Remove Jenkins job references to devops-gate/master in lin…

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -26,7 +26,6 @@ export SUPPORTED_KERNEL_FLAVORS="generic aws gcp azure oracle"
 # for testing purposes to use jenkins-ops.<developer> instead.
 #
 export JENKINS_OPS_DIR="${JENKINS_OPS_DIR:-jenkins-ops}"
-export S3_DEVOPS_BRANCH="${S3_DEVOPS_BRANCH:-master}"
 
 export UBUNTU_DISTRIBUTION="focal"
 
@@ -660,7 +659,7 @@ function determine_dependencies_base_url() {
 		[[ -n "$suv" ]] || die "No artifacts found at $url"
 		DEPENDENCIES_BASE_URL="$url/$suv/input-artifacts/combined-packages/packages"
 	else
-		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/devops-gate/$S3_DEVOPS_BRANCH/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
+		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
 	fi
 
 	#


### PR DESCRIPTION
TOOL-12470 Remove Jenkins job references to devops-gate/master in lin…

# Problem:

As part of http://reviews.delphix.com/r/75405/ we are removing devops-gate/master from the job hierarchy on Jenkins. Need to update all the references.

# Solution:

Remove references.

# Testing

Ran a pre-push build-package from my dev instance. (This failed purposefully since the JENKINS_OPS_DIR points to my developer Jenkins ID)
http://ops.jtor-docker.dcol2.delphix.com/job/linux-pkg/job/master/job/build-package/job/virtualization/job/pre-push/1/consoleFull

Things to note are:

No S3_DEVOPS_BRANCH

```
18:10:11  Build Environment Variables:
18:10:11    PACKAGE_NAME: virtualization
18:10:11    DEFAULT_GIT_BRANCH: master
18:10:11    DELPHIX_SIGNATURE_VERSION: 6.1
18:10:11    DELPHIX_RELEASE_VERSION: 6.1.0.0
18:10:11    JENKINS_OPS_DIR: jenkins-ops.jorge.torres
18:10:11    PACKAGE_GIT_URL: 
18:10:11    PACKAGE_GIT_BRANCH: 
18:10:11    DEFAULT_REVISION: 
18:10:11    TARGET_KERNEL_FLAVORS: null
18:10:11    DELPHIX_PACKAGE_MIRROR_MAIN: 
18:10:11    DELPHIX_PACKAGE_MIRROR_SECONDARY: 
18:10:11    DEPENDENCIES_BASE_URL: null
```

The S3 path here doesn't have `devops-gate/master` as desired.
```
18:11:24  Running: aws s3 ls s3://snapshot-de-images/builds/jenkins-ops.jorge.torres/linux-pkg/master/build-package
18:11:28  Error: failed command 'aws s3 ls s3://snapshot-de-images/builds/jenkins-ops.jorge.torres/linux-pkg/master/build-package'
```

# Deployment Plan:

This needs to be merged after the new Jenkins controllers have been deployed. Otherwise, jobs would fail to fetch the right artifacts on S3 since the JOB_NAME will differ.

