### PR TITLE
CP-6693 linux-pkg config for fluentd-gems package

### DIFF
--- a/packages/fluentd-gems/config.sh
+++ b/packages/fluentd-gems/config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/fluentd-gems.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
As per Prakash's comments in [PR 209](https://github.com/delphix/linux-pkg/pull/209) I have split out the fluentd-gems config changes and cleaned up the copyright.  

"you need to add the packages config.sh file, and add the package to main.pkgs in two independent PRs.. in order to avoid build failures.. the sequence need to be:

add the package's config.sh file
build the package in Jenkins
add the package to main.pkgs
If we don't perform (2) prior to (3), the Jenkins "combine-packages" job will fail to find the package for "fluentd-gems", and result in build failures (e.g. for git-ab-pre-push).. and we can't perform (2), until we've performed (1)..

So, while this is a bit of an awkward dance we need to perform, it's necessary given the current architecture, if we want to avoid impact to others (in the form of transient build failures).."


Testing:  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/6644/

I'm not sure exactly what this job will do.  I pointed it at my linux-pkg repo but it wouldn't accept fluentd-gems as a package to rebuild since it's not listed in main.pkgs.   