### PR TITLE
TOOL-12539 [Backport of TOOL-12470 to 6.0/migration] Remove Jenkins job references to devops-gate/master in linux-pkg

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -629,7 +629,7 @@ function determine_dependencies_base_url() {
 		[[ -n "$suv" ]] || die "No artifacts found at $url"
 		DEPENDENCIES_BASE_URL="$url/$suv/input-artifacts/combined-packages/packages"
 	else
-		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/devops-gate/master/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
+		DEPENDENCIES_BASE_URL="s3://snapshot-de-images/builds/$JENKINS_OPS_DIR/linux-pkg/$DEFAULT_GIT_BRANCH/build-package"
 	fi
 
 	#


### PR DESCRIPTION
Dirty cherry-pick of https://github.com/delphix/linux-pkg/pull/207

There was no S3_DEVOPS_BRANCH defined so that part didn't have to be backported.
