### PR TITLE
CP-7142 - [Backport of CP-6693 to 6.0.13.0] linux-pkg config for flue…

### DIFF
--- a/packages/fluentd-gems/config.sh
+++ b/packages/fluentd-gems/config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/fluentd-gems.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}


### PR DESCRIPTION
Clean cherry-pick.

This is the first stage in backporting the fluentd plugin project.  The stage branch of the fluentd-gems repo was populated on creation of the branches.  We can start building the fluentd-gems package.  