### PR TITLE
CP-7145 [Backport of CP-5327 to 6.0.13.0] Simplify the fluentd build

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -14,6 +14,7 @@ delphix-rust
 delphix-sso-app
 drgn
 docker-python-image
+fluentd-gems
 gdb-python
 grub2
 host-jdks


### PR DESCRIPTION
Clean cherry-pick.   

