### PR TITLE
CP-7145 [Backport of CP-5327 to 6.0.13.0] Simplify the fluentd build  part 2

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -49,13 +49,9 @@ function fetch() {
 
 	#
 	# Note about the debs being fetched:
-	# - td-agent was built by the "td-agent" linux-pkg package, but it
-	#   now fails to build due to broken third party dependencies. See
-	#   DLPX-69338 and DLPX-68211.
 	# - unzip was added as a temporary workaround to DLPX-73555.
 	#
 	local debs=(
-		"td-agent_3.5.0-delphix-2019.09.18.20_amd64.deb 84dfa2436039ff2a6312484bd7295ebaf570b5f59f100380b57e68b4800855c4"
 		"unzip_6.0-21ubuntu1_amd64.deb d46069c369ce88c8dd91c52abb8de8d6053606748ef18b3b9bc290fdd8ad2953"
 	)
 


### PR DESCRIPTION
When integrating CP-5327 (along with app-gate and appliance build changes) into master, app-gate integrations tests failed because of a missing fluentd-gems package.  In order to avoid a similar scenario in stage I will split this backport into two parts.  First, making sure the fluentd-gems package is installed and then updating the td-agent package.  

Then in part two, switch from the delphix built td-agent package to the standard focal td-agent package.  This goes to gether with changes to  the [appliance-build ](url)([delphix/appliance-build#655)](https://github.com/delphix/appliance-build/pull/655) and [app-gate](http://reviews.delphix.com/r/77706/) .
