### PR TITLE
 CP-7238 consolidate kernel versions to 5.4 

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1086,10 +1086,7 @@ function get_kernel_version_for_platform_from_apt() {
 	# available, it is not always the case.
 	#
 
-	if [[ "$platform" == generic ]] &&
-		[[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
-		package=linux-image-generic-hwe-18.04
-	elif [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
+	if [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
 		package="linux-image-${platform}-lts-20.04"
 	else
 		package="linux-image-${platform}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1089,6 +1089,8 @@ function get_kernel_version_for_platform_from_apt() {
 	if [[ "$platform" == generic ]] &&
 		[[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
 		package=linux-image-generic-hwe-18.04
+	elif [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
+		package="linux-image-${platform}-lts-20.04"
 	else
 		package="linux-image-${platform}"
 	fi


### PR DESCRIPTION
This change causes our upstream to be set to the LTS kernel for the various cloud platforms. This will cause us to use the 5.4 kernel instead of 5.11; this will work around an issue with the kernel pipe code in 5.11.

Testing:
Kernel build: http://ops.jenkins.delphix.com/job/linux-pkg/job/master/job/build-kernel/job/pre-push/35/console
appliance-build: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/652/ (upgrade tests are failing due to DLPX-79397)
AWS blackbox: http://selfservice.jenkins.delphix.com/job/blackbox-self-service/8451/consoleFull
GCP blackbox: http://selfservice.jenkins.delphix.com/job/blackbox-self-service/8453/consoleFull
Azure blackbox: http://selfservice.jenkins.delphix.com/job/blackbox-self-service/8501/consoleFull ;  this run has failures, I'm trying to determine if they're the result of the kernel change or something else. Nightly runs see different timeout failures, but they do see man failures.
