### PR TITLE
CP-6910 update appliance-build job to add option to build both resour…

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -59,7 +59,7 @@ function build() {
 	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
 		logmust ant -Ddockerize=true -DbuildJni=true \
 			-DhotfixGenDlpxVersion="$DELPHIX_RELEASE_VERSION" \
-			all package
+			-Dbuild.legacy.resources.war=true all package
 	else
 		logmust ant -Ddockerize=true -DbuildJni=true all package
 	fi


### PR DESCRIPTION
…ces.war and resources_legacy.war

In app-gate, we recently added an option to build two resources.war. One with Netty 3.10 and another with Netty 4.1.
We want to build both resources.war only for nightly and release builds. 

Tests:
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/805/ --> ab-pre-push job with linux-pkg pointing to my fork.