### PR TITLE
CP-7227 Upgrade Engine JDK to version jdk322-b06

### DIFF
--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2022 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -19,8 +19,8 @@
 DEFAULT_PACKAGE_GIT_URL=none
 PACKAGE_DEPENDENCIES="make-jpkg"
 
-_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz"
-_tarfile_sha256="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a"
+_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u322b06.tar.gz"
+_tarfile_sha256="3d62362a78c9412766471b05253507a4cfc212daea5cdf122860173ce902400e"
 _jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 
 function prepare() {


### PR DESCRIPTION
ab-pre-push - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/1176/

Verified the java version is updated to the latest by cloning an engine from image created from orchestrator run.

The failing test in the orchestrator run is fixed in http://reviews.delphix.com/r/79437/diff/1/.