### PR TITLE
DLPX-82230 add delphix/fio to linux-pkg

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -14,6 +14,7 @@ delphix-rust
 delphix-sso-app
 drgn
 docker-python-image
+fio
 fluentd-gems
 gdb-python
 grub2

--- a/packages/fio/config.sh
+++ b/packages/fio/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2022 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/fio/config.sh
+++ b/packages/fio/config.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018, 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/fio.git"
+
+function prepare() {
+        logmust install_pkgs \
+            libaio-dev \
+            librdmacm-dev \
+            libibverbs-dev \
+            librbd-dev \
+            libgtk2.0-dev \
+            libcairo2-dev \
+            libnuma-dev \
+            flex \
+            bison \
+            libglusterfs-dev \
+            libpmem-dev \
+            libpmemblk-dev
+}
+
+
+function build() {
+        logmust cd "$WORKDIR/repo/"
+        logmust dpkg-buildpackage -b -us -uc
+        logmust mv $WORKDIR/*deb "$WORKDIR/artifacts/"
+}


### PR DESCRIPTION
Adding the delphix/fio repo to the list of packages. 
delphix/fio uses python3 instead of python2.7 from https://packages.ubuntu.com/focal/fio 
Testing: ab-pre-push http://selfservice.jenkins-sbala.dcol2.delphix.com/job/appliance-build-orchestrator-pre-push/3/
The virtualization packages depend on fio