### PR TITLE
GHM-743 transition more platform repository to pre-gitflow branching model

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1075,9 +1075,8 @@ function get_kernel_version_for_platform_from_apt() {
 	# available, it is not always the case.
 	#
 
-	if [[ "$platform" == generic ]] &&
-		[[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
-		package=linux-image-generic-hwe-18.04
+	if [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
+		package="linux-image-${platform}-lts-20.04"
 	else
 		package="linux-image-${platform}"
 	fi


### PR DESCRIPTION
This is a git merge of `master` into `6.0/stage`; this is in preparation for development to be done directly on `6.0/stage` instead of `master`.

There were minor conflicts that had to be resolved, see [here](https://github.com/delphix/linux-pkg/pull/238/commits/2f986d37471c49618430e58f2c9207060e421fa7).

There are minor diffs with master after completing this merge:
```
$ git diff origin/master
diff --git a/branch.config b/branch.config
index 506ef72..705e477 100644
--- a/branch.config
+++ b/branch.config
@@ -11,4 +11,4 @@
 # branching.
 #
 
-DEFAULT_GIT_BRANCH="master"
+DEFAULT_GIT_BRANCH="6.0/stage"
diff --git a/packages/zfs/config.sh b/packages/zfs/config.sh
index 3cea75c..f8d40da 100644
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -19,6 +19,9 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/zfs.git"
 PACKAGE_DEPENDENCIES="@linux-kernel delphix-rust"
 
+UPSTREAM_GIT_URL="https://github.com/openzfs/zfs.git"
+UPSTREAM_GIT_BRANCH="master"
+
 function prepare() {
    logmust install_pkgs \
        alien \
@@ -163,3 +166,7 @@ function build() {
    logmust cd "$WORKDIR"
    logmust mv "all-packages/"*.deb "artifacts/"
 }
+
+function update_upstream() {
+   logmust update_upstream_from_git
+}
```

The diff in `packages/zfs/config.sh` is due to the fact that we don't want to pull in the changes from 762b9fd.