### PR TITLE
TOOL-15609 Tweak linux-pkg to support ARM builds 

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -574,8 +574,16 @@ function list_linux_kernel_packages() {
 
 function install_shfmt() {
 	if [[ ! -f /usr/local/bin/shfmt ]]; then
+		local arch
+		arch=$(dpkg-architecture -q DEB_HOST_ARCH)
+
+		# The release names for shfmt don't use the actual
+		# architecture strings, unfortunately.
+		if [[ "$arch" == "arm64" ]]; then
+			arch="arm"
+		fi
 		logmust sudo wget -nv -O /usr/local/bin/shfmt \
-			https://github.com/mvdan/sh/releases/download/v2.4.0/shfmt_v2.4.0_linux_amd64
+			https://github.com/mvdan/sh/releases/download/v2.4.0/shfmt_v2.4.0_linux_$arch
 		logmust sudo chmod +x /usr/local/bin/shfmt
 	fi
 	echo "shfmt version $(shfmt -version) is installed."

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -28,5 +28,5 @@ function prepare() {
 function build() {
 	logmust cd "$WORKDIR/repo/challenge_response"
 	logmust make package
-	logmust mv ./x86_64/*deb "$WORKDIR/artifacts/"
+	logmust mv "./$(dpkg-architecture -q DEB_HOST_GNU_CPU)"/*deb "$WORKDIR/artifacts/"
 }


### PR DESCRIPTION
These changes allow packages to be built on an ARM version of the bootstrap image. Other changes are required to specific packages and in the short term, workarounds are required for dependency fetching. I may also post a PR with a version of the dependency changes for an improved development workflow.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/3300/console (in progress, build step succeeded), manually tested on ARM bootstrap-equivalent and amd64 bootstrap VM.