### PR TITLE
TOOL-15610 Add flag to buildpkg to cause the build to use locally-built dependencies

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -39,6 +39,7 @@ function usage() {
 	echo "    -c  also run package's checkstyle hook."
 	echo "    -r  override default revision for package."
 	echo "    -h  display this message and exit."
+	echo "    -l  use locally-built dependencies instead of s3 versions."
 	echo ""
 	exit 2
 }
@@ -48,13 +49,15 @@ unset PARAM_PACKAGE_GIT_BRANCH
 unset PARAM_PACKAGE_REVISION
 
 do_checkstyle=false
-while getopts ':b:cg:hr:' c; do
+source="s3"
+while getopts ':b:cg:hlr:' c; do
 	case "$c" in
 	g) export PARAM_PACKAGE_GIT_URL="$OPTARG" ;;
 	b) export PARAM_PACKAGE_GIT_BRANCH="$OPTARG" ;;
 	r) export PARAM_PACKAGE_REVISION="$OPTARG" ;;
 	c) do_checkstyle=true ;;
 	h) usage >&2 ;;
+	l) source="local" ;;
 	*) usage "illegal option -- $OPTARG" >&2 ;;
 	esac
 done
@@ -86,7 +89,7 @@ logmust cd "$WORKDIR"
 stage fetch
 
 logmust cd "$WORKDIR"
-stage fetch_dependencies
+stage fetch_dependencies $source
 
 logmust cd "$WORKDIR"
 stage prepare


### PR DESCRIPTION
This PR adds a flag to buildpkg that allows the user to force the build process to use dependencies built locally in the repository instead of fetching them from s3. This is useful when doing rapid iteration or developing on new architectures, where the s3 versions do not work or do not contain necessary changes for testing.

Tested manually with and without the -l flag in use.