### PR TITLE
TOOL-15610 Add flag to buildpkg to cause the build to use locally-built dependencies (#251) (revert)

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -39,7 +39,6 @@ function usage() {
 	echo "    -c  also run package's checkstyle hook."
 	echo "    -r  override default revision for package."
 	echo "    -h  display this message and exit."
-	echo "    -l  use locally-built dependencies instead of s3 versions."
 	echo ""
 	exit 2
 }
@@ -49,15 +48,13 @@ unset PARAM_PACKAGE_GIT_BRANCH
 unset PARAM_PACKAGE_REVISION
 
 do_checkstyle=false
-source="s3"
-while getopts ':b:cg:hlr:' c; do
+while getopts ':b:cg:hr:' c; do
 	case "$c" in
 	g) export PARAM_PACKAGE_GIT_URL="$OPTARG" ;;
 	b) export PARAM_PACKAGE_GIT_BRANCH="$OPTARG" ;;
 	r) export PARAM_PACKAGE_REVISION="$OPTARG" ;;
 	c) do_checkstyle=true ;;
 	h) usage >&2 ;;
-	l) source="local" ;;
 	*) usage "illegal option -- $OPTARG" >&2 ;;
 	esac
 done
@@ -89,7 +86,7 @@ logmust cd "$WORKDIR"
 stage fetch
 
 logmust cd "$WORKDIR"
-stage fetch_dependencies $source
+stage fetch_dependencies
 
 logmust cd "$WORKDIR"
 stage prepare

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -214,7 +214,6 @@ function check_git_ref() {
 #
 function stage() {
 	typeset hook=$1
-	shift 1
 
 	check_env PACKAGE
 	local stage_start=$SECONDS
@@ -222,7 +221,7 @@ function stage() {
 	echo ""
 	if type -t "$hook" >/dev/null; then
 		echo_bold "PACKAGE $PACKAGE: STAGE $hook STARTED"
-		logmust "$hook" "$@"
+		logmust "$hook"
 		echo_bold "PACKAGE $PACKAGE: STAGE $hook COMPLETED in" \
 			"$((SECONDS - stage_start)) seconds"
 	else
@@ -700,7 +699,6 @@ function get_package_dependency_s3_url() {
 # is defined in the package's config.
 #
 function fetch_dependencies() {
-	local source="$1"
 	export DEPDIR="$WORKDIR/dependencies"
 	logmust mkdir "$DEPDIR"
 	logmust cd "$DEPDIR"
@@ -714,35 +712,22 @@ function fetch_dependencies() {
 	for dep in $PACKAGE_DEPENDENCIES; do
 		echo "Fetching artifacts for dependency '$dep' ..."
 		get_package_prefix "$dep"
-		case "$source" in
-		"local")
-			logmust cp -r "$WORKDIR/../../$dep/tmp/artifacts/" \
-			    "$dep/"
-			;;
-		"s3")
-			s3urlvar="${_RET}_S3_URL"
-			if [[ -n "${!s3urlvar}" ]]; then
-				s3url="${!s3urlvar}"
-				echo "S3 URL of package dependency '$dep' " \
-				    "provided externally"
-				echo "$s3urlvar=$s3url"
-			else
-				logmust get_package_dependency_s3_url "$dep"
-				s3url="$_RET"
-			fi
-			[[ "$s3url" != */ ]] && s3url="$s3url/"
-			logmust mkdir "$dep"
-			logmust aws s3 ls "$s3url"
-			logmust aws s3 cp --only-show-errors --recursive \
-			    "$s3url" "$dep/"
-			echo_bold "Fetched artifacts for '$dep' from $s3url"
-			PACKAGE_DEPENDENCIES_METADATA="" \
-			    "${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
-			;;
-		*)
-			die "invalid source parameter specified: '$source'"
-			;;
-		esac
+		s3urlvar="${_RET}_S3_URL"
+		if [[ -n "${!s3urlvar}" ]]; then
+			s3url="${!s3urlvar}"
+			echo "S3 URL of package dependency '$dep' provided" \
+				"externally"
+			echo "$s3urlvar=$s3url"
+		else
+			logmust get_package_dependency_s3_url "$dep"
+			s3url="$_RET"
+		fi
+		[[ "$s3url" != */ ]] && s3url="$s3url/"
+		logmust mkdir "$dep"
+		logmust aws s3 ls "$s3url"
+		logmust aws s3 cp --only-show-errors --recursive "$s3url" "$dep/"
+		echo_bold "Fetched artifacts for '$dep' from $s3url"
+		PACKAGE_DEPENDENCIES_METADATA="${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
 	done
 }
 


### PR DESCRIPTION
This reverts #251.. I think the problem with that PR is the change from:
```
+       PACKAGE_DEPENDENCIES_METADATA="${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
```
to
```
           PACKAGE_DEPENDENCIES_METADATA="" \
               "${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
```

here's the failure message seen with #251
```
00:07:31.302  Fetched artifacts for 'host-jdks' from s3://snapshot-de-images/builds/jenkins-ops/linux-pkg/6.0/stage/build-package/host-jdks/post-push/8/
00:07:31.302  /var/tmp/jenkins/workspace/linux-pkg/6.0/stage/build-package/virtualization/post-push/linux-pkg/lib/common.sh: line 739: host-jdks: s3://snapshot-de-images/builds/jenkins-ops/linux-pkg/6.0/stage/build-package/host-jdks/post-push/8/\n: No such file or directory
00:07:31.302  Error: failed command 'fetch_dependencies s3'
```

IMO, since #251 isn't strictly necessary, we can revert this, and then just re-integrate with the fix in place.