### PR TITLE
TOOL-15610 Add flag to buildpkg to cause the build to use locally-built dependencies (fix build breakage)

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -716,15 +716,13 @@ function fetch_dependencies() {
 		get_package_prefix "$dep"
 		case "$source" in
 		"local")
-			logmust cp -r "$WORKDIR/../../$dep/tmp/artifacts/" \
-			    "$dep/"
+			logmust cp -r "$WORKDIR/../../$dep/tmp/artifacts/ $dep/"
 			;;
 		"s3")
 			s3urlvar="${_RET}_S3_URL"
 			if [[ -n "${!s3urlvar}" ]]; then
 				s3url="${!s3urlvar}"
-				echo "S3 URL of package dependency '$dep' " \
-				    "provided externally"
+				echo "S3 URL of package dependency '$dep' provided externally"
 				echo "$s3urlvar=$s3url"
 			else
 				logmust get_package_dependency_s3_url "$dep"
@@ -733,11 +731,9 @@ function fetch_dependencies() {
 			[[ "$s3url" != */ ]] && s3url="$s3url/"
 			logmust mkdir "$dep"
 			logmust aws s3 ls "$s3url"
-			logmust aws s3 cp --only-show-errors --recursive \
-			    "$s3url" "$dep/"
+			logmust aws s3 cp --only-show-errors --recursive "$s3url" "$dep/"
 			echo_bold "Fetched artifacts for '$dep' from $s3url"
-			PACKAGE_DEPENDENCIES_METADATA="" \
-			    "${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
+			PACKAGE_DEPENDENCIES_METADATA="${PACKAGE_DEPENDENCIES_METADATA}$dep: $s3url\\n"
 			;;
 		*)
 			die "invalid source parameter specified: '$source'"


### PR DESCRIPTION
This is is a follow-on to the previous review that fixes a build breakage caused by this change. Because there is whitespace between the two halves of the string assignment, the second half is instead treated as a command to execute. This causes the build to fail. The change contained herein works to fix the issue, but I suspect it will cause the style checker to complain. Is there a more stylistic way to implement this?