### PR TITLE
DLPX-83163 Add ARM support for adoptopenjdk package

### DIFF
--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -39,6 +39,12 @@ function prepare() {
 }
 
 function fetch() {
+	# We exit here rather than above in the architecture detection logic
+	# to deal with the fact that this file can, during test runs, be
+	# sourced on platforms where builds are not happening. list-packages
+	# sources the file to gather information about the package, and this
+	# is performed on jenkins and macos during test runs. Having the exit
+	# occur above causes those runs to fail.
 	if [[ -z "$_tarfile" ]]; then
 		echo "Invalid architecture detected" >&2
 		exit 1

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -19,7 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL=none
 PACKAGE_DEPENDENCIES="make-jpkg"
 
-case $(dpkg-architecture -q DEB_HOST_ARCH) in
+case $(dpkg-architecture -q DEB_HOST_ARCH 2>/dev/null || echo "none") in
 amd64)
 	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
 	_tarfile_sha256="ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58"
@@ -30,10 +30,8 @@ arm64)
 	_tarfile_sha256="c1965fb24dded7d7944e2da36cd902adf3b7b1d327aaa21ea507cff00a5a0090"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-arm64"
 	;;
-*)
-	echo "Invalid architecture detected" >&2
-	exit 1
-	;;
+*) ;;
+
 esac
 
 function prepare() {
@@ -41,6 +39,10 @@ function prepare() {
 }
 
 function fetch() {
+	if [[ -z "$_tarfile" ]]; then
+		echo "Invalid architecture detected" >&2
+		exit 1
+	fi
 	logmust cd "$WORKDIR/"
 
 	local url="http://artifactory.delphix.com/artifactory/java-binaries/linux/jdk/8/$_tarfile"
@@ -49,6 +51,10 @@ function fetch() {
 }
 
 function build() {
+	if [[ -z "$_tarfile" ]]; then
+		echo "Invalid architecture detected" >&2
+		exit 1
+	fi
 	logmust cd "$WORKDIR/"
 
 	logmust env DEB_BUILD_OPTIONS=nostrip fakeroot make-jpkg "$_tarfile" <<<y

--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -19,15 +19,22 @@
 DEFAULT_PACKAGE_GIT_URL=none
 PACKAGE_DEPENDENCIES="make-jpkg"
 
-if [[ "$UPSTREAM_PRODUCT_BRANCH" == "master" ]]; then
+case $(dpkg-architecture -q DEB_HOST_ARCH) in
+amd64)
 	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
 	_tarfile_sha256="ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
-else
-	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
-	_tarfile_sha256="ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58"
-	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
-fi
+	;;
+arm64)
+	_tarfile="OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz"
+	_tarfile_sha256="c1965fb24dded7d7944e2da36cd902adf3b7b1d327aaa21ea507cff00a5a0090"
+	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-arm64"
+	;;
+*)
+	echo "Invalid architecture detected" >&2
+	exit 1
+	;;
+esac
 
 function prepare() {
 	logmust install_pkgs "$DEPDIR"/make-jpkg/*.deb


### PR DESCRIPTION
Now that the OpenJDK build for arm64 has been added for artifactory, this PR enables ARM builds for the `adoptopenjdk` package.  Note that the removed code is identical to the untouched code, so I simplified the logic at the same time.

Tested manually on arm and amd64 bootstrap VMs.