### PR TITLE
GHM-824 Build masking and containerized masking packages with secrets

### DIFF
--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -40,6 +40,32 @@ function build() {
 
 	logmust cd "$WORKDIR/repo"
 
+	if [[ "$SECRET_DB_AWS_ENDPOINT" ]]; then
+		export SECRET_DB_AWS_ENDPOINT="$SECRET_DB_AWS_ENDPOINT"
+	fi
+
+	# Using secrets proxy
+	if [[ "$SECRET_DB_USE_JUMPBOX" ]]; then
+		export SECRET_DB_USE_JUMPBOX="$SECRET_DB_USE_JUMPBOX"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_HOST" ]]; then
+		export SECRET_DB_JUMP_BOX_HOST="$SECRET_DB_JUMP_BOX_HOST"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_USER" ]]; then
+		export SECRET_DB_JUMP_BOX_USER="$SECRET_DB_JUMP_BOX_USER"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
+		export SECRET_DB_JUMP_BOX_PRIVATE_KEY="$SECRET_DB_JUMP_BOX_PRIVATE_KEY"
+	fi
+
+	# Using master/eng-secret-user
+	if [[ "$SECRET_DB_AWS_PROFILE" ]]; then
+		export SECRET_DB_AWS_PROFILE="$SECRET_DB_AWS_PROFILE"
+	fi
+	if [[ "$SECRET_DB_AWS_REGION" ]]; then
+		export SECRET_DB_AWS_REGION="$SECRET_DB_AWS_REGION"
+	fi
+
 	logmust ./gradlew --no-daemon --stacktrace \
 		-Porg.gradle.configureondemand=false \
 		-PenvironmentName=linuxappliance \

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -43,6 +43,32 @@ function build() {
 		'{ "dms-core-gate" : { "git-hash" : $h, "date": $d }}' \
 		>"$WORKDIR/artifacts/metadata.json"
 
+	if [[ "$SECRET_DB_AWS_ENDPOINT" ]]; then
+		export SECRET_DB_AWS_ENDPOINT="$SECRET_DB_AWS_ENDPOINT"
+	fi
+
+	# Using secrets proxy
+	if [[ "$SECRET_DB_USE_JUMPBOX" ]]; then
+		export SECRET_DB_USE_JUMPBOX="$SECRET_DB_USE_JUMPBOX"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_HOST" ]]; then
+		export SECRET_DB_JUMP_BOX_HOST="$SECRET_DB_JUMP_BOX_HOST"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_USER" ]]; then
+		export SECRET_DB_JUMP_BOX_USER="$SECRET_DB_JUMP_BOX_USER"
+	fi
+	if [[ "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
+		export SECRET_DB_JUMP_BOX_PRIVATE_KEY="$SECRET_DB_JUMP_BOX_PRIVATE_KEY"
+	fi
+
+	# Using master/eng-secret-user
+	if [[ "$SECRET_DB_AWS_PROFILE" ]]; then
+		export SECRET_DB_AWS_PROFILE="$SECRET_DB_AWS_PROFILE"
+	fi
+	if [[ "$SECRET_DB_AWS_REGION" ]]; then
+		export SECRET_DB_AWS_REGION="$SECRET_DB_AWS_REGION"
+	fi
+
 	logmust ./gradlew --no-daemon --stacktrace \
 		-Porg.gradle.configureondemand=false \
 		-PenvironmentName=linuxappliance \


### PR DESCRIPTION
# Problem

masking and containerized masking package builds need to retrieve secrets from AWS. 

This is especially critical for when [DLPX-81645 Remove secrets from tip of dms-core-gate repo](https://delphix.atlassian.net/browse/DLPX-81645) changes are integrated.

# Testing

```sh
→ git-ab-pre-push -b "masking" --jenkins-url=http://selfservice.pkg-test.dcol2.delphix.com
Your build is at: http://selfservice.pkg-test.dcol2.delphix.com/job/appliance-build-orchestrator-pre-push/7/
```

Per http://selfservice.pkg-test.dcol2.delphix.com/job/linux-pkg/job/6.0/job/stage/job/build-package/job/masking/job/pre-push/5/console:
```
13:25:13  Success: Package masking has been built successfully.
```

# Future Improvements

See  [GHM-833](https://delphix.atlassian.net/browse/GHM-833).