### PR TITLE
GHM-822 Build virtalization package with secrets (#256) (revert)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 tmp/
 /artifacts/
-.idea

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -56,56 +56,13 @@ function build() {
 	# Build the virtualization package
 	#
 	logmust cd "$WORKDIR/repo/appliance"
-
-	local args=()
-
-	# Because ant does not read the environment variables of the execution context, we set them as
-	# parameters only if they exist in the execution context
-
-	# Here we check for whether the environment variables are set and pass them along. We check for
-	# existence instead of emptiness to avoid adding a layer of interpretation.
-
-	# We use parameter expansion in the form of ${variable+nothing} which evaluates to the variable
-	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
-	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
-
-	if [[ ${SECRET_DB_USE_JUMPBOX+nothing} ]]; then
-		args+=("-DSECRET_DB_USE_JUMPBOX=\"$SECRET_DB_USE_JUMPBOX\"")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_HOST+nothing} ]]; then
-		args+=("-DSECRET_DB_JUMP_BOX_HOST=\"$SECRET_DB_JUMP_BOX_HOST\"")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_USER+nothing} ]]; then
-		args+=("-DSECRET_DB_JUMP_BOX_USER=\"$SECRET_DB_JUMP_BOX_USER\"")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_PRIVATE_KEY+nothing} ]]; then
-		args+=("-DSECRET_DB_JUMP_BOX_PRIVATE_KEY=\"$SECRET_DB_JUMP_BOX_PRIVATE_KEY\"")
-	fi
-
-	if [[ ${SECRET_DB_AWS_ENDPOINT+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_ENDPOINT=\"$SECRET_DB_AWS_ENDPOINT\"")
-	fi
-
-	if [[ ${SECRET_DB_AWS_PROFILE+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_PROFILE=\"$SECRET_DB_AWS_PROFILE\"")
-	fi
-
-	if [[ ${SECRET_DB_AWS_REGION+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_REGION=\"$SECRET_DB_AWS_REGION\"")
-	fi
-
-	args+=("-Ddockerize=true")
-	args+=("-DbuildJni=true")
-
 	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
-		args+=("-DhotfixGenDlpxVersion=\"$DELPHIX_RELEASE_VERSION\"")
-		args+=("-Dbuild.legacy.resources.war=true")
+		logmust ant -Ddockerize=true -DbuildJni=true \
+			-DhotfixGenDlpxVersion="$DELPHIX_RELEASE_VERSION" \
+			-Dbuild.legacy.resources.war=true all package
+	else
+		logmust ant -Ddockerize=true -DbuildJni=true all package
 	fi
-
-	logmust ant "${args[@]}" all-secrets package
 
 	#
 	# Publish the virtualization package artifacts


### PR DESCRIPTION
The automated tests that said the changes worked with a successful git-ab-prepush didn't actually build linux-pkg and the affected virtualization package. The automation provided a false negative test.