### PR TITLE
TOOL-16515 Make dependency on "build-essential" explicit

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -116,6 +116,7 @@ logmust sudo apt-get update
 # - jq is used to generate a JSON formatted metadata file by some packages.
 #
 logmust install_pkgs \
+	build-essential \
 	debhelper \
 	devscripts \
 	equivs \


### PR DESCRIPTION
We currently depend on the "build-essential" package being installed,
but don't explictly install it; we rely on it already being installed on
the system we're building on. This change makes this dependency
explicit, and we now pull it in if it's not already installed; as we do
for other packages we depend on.
