### PR TITLE
TOOL-16602 Install "pahole" to enable BTF for kernel builds

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -39,7 +39,8 @@ function kernel_prepare() {
 	logmust install_pkgs \
 		equivs \
 		devscripts \
-		kernel-wedge
+		kernel-wedge \
+		dwarves # installs pahole(1) needed for BTF
 }
 
 #


### PR DESCRIPTION
This is a continuation of https://github.com/delphix/linux-pkg/pull/171