### PR TITLE
TOOL-16770 Add rsync to package build dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -138,6 +138,7 @@ logmust install_pkgs \
 	debhelper \
 	devscripts \
 	equivs \
+	rsync \
 	shellcheck \
 	jq
 


### PR DESCRIPTION
The masking config.sh uses "rsync" so we need to ensure it's installed.
