### PR TITLE
TOOL-16833 Update masking and containerized masking package builds to pull from dms-core-gate GitHub repo not Gitlab

### DIFF
--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -24,7 +24,7 @@
 # only works with packages that are included in the appliance, which this one
 # isn't.
 #
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/masking/dms-core-gate.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dms-core-gate.git"
 
 PACKAGE_DEPENDENCIES="adoptopenjdk"
 SKIP_COPYRIGHTS_CHECK=true

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -16,7 +16,7 @@
 #
 # shellcheck disable=SC2034
 
-DEFAULT_PACKAGE_GIT_URL="https://gitlab.delphix.com/masking/dms-core-gate.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dms-core-gate.git"
 PACKAGE_DEPENDENCIES="adoptopenjdk"
 
 function prepare() {


### PR DESCRIPTION
Post-migration of the dms-core-gate repo to GitHub from GitLab, the masking and containerized masking package builds need to pull from the GitHub repo and not the GitLab repo.