### PR TITLE
DLPX-83885 Clean up appliance build; resources_legacy.war can no longer be built

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -102,7 +102,6 @@ function build() {
 
 	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
 		args+=("-DhotfixGenDlpxVersion=$DELPHIX_RELEASE_VERSION")
-		args+=("-Dbuild.legacy.resources.war=true")
 	fi
 
 	logmust ant "${args[@]}" all-secrets package


### PR DESCRIPTION
### Problem
Jira Description: Clean up appliance build; resources_legacy.war can no longer be built
 
### Solution
Since legacy war can not be created, removing the args