### PR TITLE
DLPX-79631 Decide on a way to retain more of the Ubuntu revision information so that we can more easily determine what's in the package

### DIFF
--- a/buildpkg.sh
+++ b/buildpkg.sh
@@ -73,7 +73,7 @@ check_env DEFAULT_GIT_BRANCH
 # DEFAULT_REVISION & DEFAULT_GIT_BRANCH will be set if called from buildlist.sh.
 # If the script is called manually, we set it here.
 #
-DEFAULT_REVISION="${DEFAULT_REVISION:-$(default_revision)}"
+DEFAULT_REVISION="${DEFAULT_REVISION:-$(delphix_revision)}"
 
 echo ""
 echo_bold "===================================================================="

--- a/checkupdates.sh
+++ b/checkupdates.sh
@@ -52,7 +52,7 @@ logmust check_package_exists "$PACKAGE"
 #
 # If the script is called manually, we set it here.
 #
-DEFAULT_REVISION="${DEFAULT_REVISION:-$(default_revision)}"
+DEFAULT_REVISION="${DEFAULT_REVISION:-$(delphix_revision)}"
 
 logmust load_package_config "$PACKAGE"
 logmust create_workdir

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -95,7 +95,7 @@ function build() {
 
 	local hash
 	logmust eval hash="$(git rev-parse --short HEAD)"
-	logmust sed -i "s/^Version:.*/Version:      $PACKAGE_VERSION+1$PACKAGE_REVISION/" \
+	logmust sed -i "s/^Version:.*/Version:      $PACKAGE_VERSION/" \
 		META || die "failed to set Version"
 	logmust sed -i "s/^Release:.*/Release:      1$PACKAGE_REVISION-$hash/" \
 		META || die "failed to set Release"

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -95,8 +95,10 @@ function build() {
 
 	local hash
 	logmust eval hash="$(git rev-parse --short HEAD)"
-	logmust sed -i "s/^Release:.*/Release:      $PACKAGE_REVISION-$hash/" \
-		META || die "failed to set version"
+	logmust sed -i "s/^Version:.*/Version:      $PACKAGE_VERSION+1$PACKAGE_REVISION/" \
+		META || die "failed to set Version"
+	logmust sed -i "s/^Release:.*/Release:      1$PACKAGE_REVISION-$hash/" \
+		META || die "failed to set Release"
 	logmust set_changelog
 
 	#

--- a/push-merge.sh
+++ b/push-merge.sh
@@ -56,7 +56,7 @@ fi
 
 logmust check_package_exists "$PACKAGE"
 
-DEFAULT_REVISION="${DEFAULT_REVISION:-$(default_revision)}"
+DEFAULT_REVISION="${DEFAULT_REVISION:-$(delphix_revision)}"
 logmust load_package_config "$PACKAGE"
 
 if [[ ! -d "$WORKDIR/repo" ]]; then


### PR DESCRIPTION
Modifying the package versioning to a format that security scans will recognize the upstream version.
I had to modify the version in the META file to satisfy zfs builds which seem to use it to create a directory.
I had to add `--allow-downgrades` since some of our packages were considered downgrades due to the versioning change.

Sample of packages before the changes:
delphix@ip-10-110-202-33:~ apt list |grep delphix
....
bcc-tools/now 0.22.0-1-delphix-2022.01.15.05 all [installed,local]
bpftrace-dbgsym/now 1.0.0-delphix-2022.01.08.17 amd64 [installed,local]
bpftrace/now 1.0.0-delphix-2022.01.08.17 amd64 [installed,local]
cloud-init/now 21.4-delphix-2022.01.08.17 all [installed,local]
....
After
delphix@ip-10-110-207-180:~$ apt list |grep delphix

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

bcc-tools/now 0.22.0-1+delphix.2023.06.27.16.13 all [installed,local]
bpftrace/now 1.0.0-1delphix.2023.06.27.16.49 amd64 [installed,local]
cloud-init/now 23.1.2-0ubuntu0~20.04.2+delphix.2023.06.27.16.13 all [installed,local]
connstat-module-5.15.0-1031-dx2023062716-24f86c0a3-aws/now 1.0.0-1delphix.2023.06.27.19.25 amd64 [installed,local]
connstat-util/now 1.0.0-1delphix.2023.06.27.19.25 amd64 [installed,local]
crash-python/now 1.0.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
delphix-build-info/now 1.0.0-delphix-2023.06.27.22.00.57-0ba01512 all [installed,local]
delphix-entire-aws/now 13.0.0.0-snapshot.20230627214434603+jenkins-selfservice-appliance-build-develop-pre-push-597 all [installed,local]
delphix-kernel-5.15.0-1031-dx2023062716-24f86c0a3-aws/now 1.0.0-1delphix.2023.06.27.19.25 amd64 [installed,local]
delphix-masking/now 1.0.0-20230627T210409 amd64 [installed,local]
delphix-platform-aws/now 1.0.0-delphix.2023.06.27.16.13 amd64 [installed,local]
delphix-rust/now 1.0.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
delphix-sso-app/now 2023.06.27.21 all [installed,local]
delphix-virtualization/now 2023.06.27.21 amd64 [installed,local]
delphix-zfs/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
docker-python-image/now 1.0.0-1delphix.2023.06.27.16.13 all [installed,local]
drgn/now 1.0.0-1delphix.2023.06.27.16.49 amd64 [installed,local]
fluentd-gems/now 1.0.0-1delphix.2023.06.27.16.14 amd64 [installed,local]
gdb-python/now 1.0.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
grub-common/now 2.04-1ubuntu26.17+delphix.2023.06.27.16.14 amd64 [installed,local]
grub-pc-bin/now 2.04-1ubuntu26.17+delphix.2023.06.27.16.14 amd64 [installed,local]
grub-pc/now 2.04-1ubuntu26.17+delphix.2023.06.27.16.14 amd64 [installed,local]
grub2-common/now 2.04-1ubuntu26.17+delphix.2023.06.27.16.14 amd64 [installed,local]
host-jdks/now 1.0.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
kdump-tools/now 1:1.6.7-1ubuntu2.4+delphix.2023.06.27.16.14 amd64 [installed,local]
libbcc/now 0.22.0-1+delphix.2023.06.27.16.13 amd64 [installed,local]
libkdumpfile/now 0.3.0-1delphix.2023.06.27.16.14 amd64 [installed,local]
libnvpair1linux/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
libuutil1linux/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
libzfs2linux/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
libzfslinux-dev/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
libzpool2linux/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
makedumpfile/now 1:1.6.7-1ubuntu2.4+delphix.2023.06.27.16.14 amd64 [installed,local]
nfs-common/now 1:1.3.4-2.5ubuntu3.4+delphix.2023.06.27.16.14 amd64 [installed,local]
nfs-kernel-server/now 1:1.3.4-2.5ubuntu3.4+delphix.2023.06.27.16.14 amd64 [installed,local]
performance-diagnostics/now 1.0.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
ptools/now 0.2.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
python3-bcc/now 0.22.0-1+delphix.2023.06.27.16.13 all [installed,local]
python3-rtslib-fb/now 2.1.71-0ubuntu1.1+delphix.2023.06.27.16.14 all [installed,local]
recovery-environment/now 1.0-1+delphix.2023.06.27.21.01 amd64 [installed,local]
savedump/now 0.1.0-1delphix.2023.06.27.16.13 amd64 [installed,local]
sdb/now 1.0.0-1delphix.2023.06.27.16.14 amd64 [installed,local]
targetcli-fb/now 1:2.1.51-0ubuntu1+delphix.2023.06.27.16.49 all [installed,local]
zfs-dbg/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfs-headers-5.15.0-1031-dx2023062716-24f86c0a3-aws/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfs-initramfs/now 2.1.99-1delphix.2023.06.27.19.25 all [installed,local]
zfs-modules-5.15.0-1031-dx2023062716-24f86c0a3-aws-dbg/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfs-modules-5.15.0-1031-dx2023062716-24f86c0a3-aws/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfs-test/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfs-zed/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]
zfsutils-linux/now 2.1.99-1delphix.2023.06.27.19.25 amd64 [installed,local]

....

Example package: 2.04-1ubuntu26.16+delphix.2023.04.10.21.43
The [version numbers in Debian](http://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version) are of the form
[epoch:]upstream_version[-debian_revision] 
where
- epoch is a single (generally small) unsigned integer, which is included to allow mistakes in the version numbers of older versions of a package. If omitted, the epoch is assumed to be zero.
- upstream_version is usually the version number of the original source package from which the .deb file has been made. It is usually kept the same as the format used for the upstream source.
- debian_revision specifies the version of the Debian package based on the upstream version. It is optional and is omitted in cases where a piece of software was written specifically to be a Debian package.

Example package: 1:2.1.51-0ubuntu1+delphix.2023.06.27.16.49
1 is epoch
2.1.51 is upstream_version
0ubuntu1+delphix.2023.06.27.16.49 is debian_revision

Testing:
Building all packages:http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/5946/  passed in ADDITIONAL_PACKAGES_TO_BUILD
QA confirmed that security scans recognize the package version.
Ran upgrade during a object storage stress run http://selfservice.jenkins.delphix.com/job/blackbox-self-service/61733/console + http://selfservice.jenkins.delphix.com/job/blackbox-self-service/61937/consoleFull and the stress run did not notice any traffic going down or change in VDB state. Only the stack went down for a few mins as part of the upgrade.