### PR TITLE
JAIL-295 jenkins containerized-masking linux-pkg job fails due to changed .zip name

### DIFF
--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -71,6 +71,6 @@ function build() {
 		-PenvironmentName=linuxappliance \
 		:tools:docker:packageMaskingKubernetes
 
-	logmust cp -v tools/docker/build/masking-kubernetes.zip \
+	logmust cp -v tools/docker/build/masking-kubernetes*.zip \
 		"$WORKDIR/artifacts/"
 }


### PR DESCRIPTION
### Problem
Recently we discovered there is an old existing containerized-masking job:
http://ops.jenkins.delphix.com/job/linux-pkg/job/6.0/job/stage/job/build-package/job/containerized-masking/job/post-push/432/console
It's defined in linux-pkg repo, and triggered by every push into dms-core-gate .
It builds the containerized ME on masking-kubernetes based linux VM, and publishes the .zip file to our AWS (S3) artifactory.
The .zip contains .tar file (with containers) + configurational .yaml file.The reason of that job started failing recently:
It tries to copy to AWS S3 the hardcoded name of the masking-kubernetes.zip :

cp: cannot stat 'tools/docker/build/masking-kubernetes.zip': No such file or directory
Error: failed command 'cp -v tools/docker/build/masking-kubernetes.zip /var/tmp/jenkins/workspace/linux-pkg/6.0/stage/build-package/containerized-masking/post-push/linux-pkg/packages/containerized-masking/tmp/artifacts/'
One of our very recent changes has added the version to that file name, for example: masking-kubernetes-7.0.0.0-c1.zip

### Solution
we still have a single `masking-kubernetes*.zip` file in teh directory we are copying from.
So generilizing the name with the `*` should solve the problem of "file is not found".
### Testing Done
I have no idea how to test that change in the `linux-pkg`.
The change I'm suggesting looks pretty safe to me. 
**Anyway we have nothing to lose. Currently that job is failing on every run** (triggered by every dms-core-gate push).
