### PR TITLE
DLPX-84041 Upgrade engine JDK to 8u362b09

### DIFF
--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2022 Delphix
+# Copyright 2018, 2023 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@ PACKAGE_DEPENDENCIES="make-jpkg"
 
 case $(dpkg-architecture -q DEB_HOST_ARCH 2>/dev/null || echo "none") in
 amd64)
-	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
-	_tarfile_sha256="ed6c9db3719895584fb1fd69fc79c29240977675f26631911c5a1dbce07b7d58"
+	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u362b09.tar.gz"
+	_tarfile_sha256="1486a792fb224611ce0cd0e83d4aacd3503b56698549f8e9a9f0a6ebb83bdba1"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 	;;
 arm64)
-	_tarfile="OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz"
-	_tarfile_sha256="c1965fb24dded7d7944e2da36cd902adf3b7b1d327aaa21ea507cff00a5a0090"
+	_tarfile="OpenJDK8U-jdk_aarch64_linux_hotspot_8u362b09.tar.gz"
+	_tarfile_sha256="9290a8beefd7a94f0eb030f62d402411a852100482b9c5b63714bacc57002c2a"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-arm64"
 	;;
 *) ;;


### PR DESCRIPTION
<!--
### Background
Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
-->
### Description
Updating the JDK in DE to jdk8u362-b09

### Notes 
Currently we are running in version 8u345b01 and upgrading it to 8u362b09
<!--
Provide a clear description of the high-level problem you are trying to
solve. The problem statement should be written in terms of a specific
symptom that affects users or the business. The problem statement should
not be written in terms of the solution. If possible, include a minimal
reproducible example (MRE) with steps to reproduce, expected results,
and actual results.
-->
<!--
### Evaluation
If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
-->
<!--### Solution

Provide a clear description of the high-level solution you have chosen.
If there were other possible solutions that you considered and rejected,
mention those along with the corresponding reasoning. Do not describe
implementation details when writing about the solution; these should go
into the implementation section instead.
-->
### Testing Done
Ran http://selfservice.jenkins.delphix.com/job/linux-pkg/job/6.0/job/stage/job/build-package/job/adoptopenjdk/job/pre-push/11/ and used the artifact to run http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4328/ dxo test failed with below error and fix for this timezone is available in https://www.github.com/delphix/dlpx-app-gate/pull/83

```
America/Argentina/Buenos_Aires, Europe/Nicosia, Pacific/Guadalcanal, Europe/Athens, US/Pacific, Europe/Monaco]>. It has unexpected items <[America/Ciudad_Juarez, Europe/Kyiv]>
	at com.google.common.truth.FailureStrategy.fail(FailureStrategy.java:28)
	at com.google.common.truth.FailureStrategy.fail(FailureStrategy.java:22)
	at com.google.common.truth.Subject.failWithRawMessage(Subject.java:438)
	at com.google.common.truth.IterableSubject.failWithBadResultsAndSuffix(IterableSubject.java:392)
	at com.google.common.truth.IterableSubject.containsExactlyElementsIn(IterableSubject.java:344)
	at com.google.common.truth.IterableSubject.containsExactlyElementsIn(IterableSubject.java:271)

```
Manually tested the jdk version by cloning a machine which was created by the ab-pre-push build.

<!--
### Implementation
Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
-->
<!--
### Deployment Plan
Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
-->
<!--
### Future Work
Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
-->
<!--
### Bonus
Provide a description of any extra problems you have solved in this pull
request.
-->