### PR TITLE
TOOL-20228 pre-cutover: linux-pkg changes for new branch naming

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ function configure_apt_sources() {
 	local secondary_url="$DELPHIX_PACKAGE_MIRROR_SECONDARY"
 
 	if [[ -z "$primary_url" ]] || [[ -z "$secondary_url" ]]; then
-		local latest_url="http://linux-package-mirror.delphix.com/"
+		local latest_url="http://10.110.21.87/"
 		if is_release_branch; then
 			package_mirror_url="${latest_url}${DEFAULT_GIT_BRANCH}"
 		else


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

For the pregitflow project, I have created `develop`, `release` and `patch`
branches in all product repos. I have also created a 3rd linux package mirror
with changes required for the renaming of the branches.
For more details, see this document: https://docs.google.com/document/d/1tHvLnX6jORHoeZqvwPP11eq-zc2usf3QyRaADCZTvEs

The production mirror's URL is hardcoded at a couple of places in this repo.
To build and test the product from these pregitflow branches, linux-pkg should
point to the test mirror when building any of these 3 branches.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Point linux-pkg to the test mirror when building pregitflow branches. My current plan is
to build these branches on a regular cadence, which is why I would like to merge this into
6.0/stage so that it also gets pushed to the `develop` branch.
This change will be reverted on the day of the cutover (when development shifts 
to these pregitflow branches).
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

build-packages on `develop`: http://ops.jenkins-palashgandhi.dcol2.delphix.com/job/linux-pkg/job/develop/job/build-packages/job/post-push/8/console
Verified that child build-package jobs point to test mirror:
```
09:57:31  Running: sudo apt-get update
09:57:31  Get:1 http://10.110.143.13/develop/849fa250/ubuntu focal InRelease [265 kB]
```

build-packages on `6.0/stage`: http://ops.jenkins-palashgandhi.dcol2.delphix.com/job/linux-pkg/job/6.0/job/stage/job/build-packages/job/post-push/1/console
Verified that child build-package jobs point to production mirror:
```
10:11:51  Running: sudo apt-get update
10:11:51  Hit:1 http://linux-package-mirror.delphix.com/6.0/stage/cbb97c65/ubuntu focal InRelease
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
