### PR TITLE
DLPX-85142 Unpin tar from linux-pkg on 6.0/stage

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -47,9 +47,7 @@ SKIP_COPYRIGHTS_CHECK=true
 function fetch() {
 	logmust cd "$WORKDIR/artifacts"
 
-	local debs=(
-		"tar_1.30+dfsg-7ubuntu0.20.04.3_amd64.deb a3b1212570b10c192b3d49cffb68f909146d4b72a7104f213f4426c7e41d0e49"
-	)
+	local debs=()
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"
 


### PR DESCRIPTION
This change unpins the `tar` package from 6.0/stage. It was added as part of DLPX-85006 in 6.0/release due to a CVE. We leave the infrastructure behind for future possibilities.
Not that branching for the new release has already completed, we are seeing some failures, unrelated to this change but that reminded me that we need to revert this on both these branches.

ab-pre-push -b misc-debs: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4834/