### PR TITLE
DLPX-85639 fix linux-pkg unit tests failing due to dwarf dependency on zfs

### DIFF
--- a/.github/scripts/verify-query-packages.sh
+++ b/.github/scripts/verify-query-packages.sh
@@ -72,7 +72,7 @@ test "$(TARGET_KERNEL_FLAVORS=generic ./query-packages.sh list linux-kernel)" ==
 # Check that when a package has multiple dependencies they are printed in the
 # expected format.
 test "$(TARGET_KERNEL_FLAVORS="generic aws" ./query-packages.sh single -o dependencies zfs)" == \
-	"linux-kernel-generic,linux-kernel-aws,delphix-rust"
+	"linux-kernel-generic,linux-kernel-aws,delphix-rust,dwarves"
 
 # Check that the output from the appliance list contains zfs and
 # delphix-platform packages. Note, we explicitly do not use grep -q here as it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,19 +2,19 @@ on: [push, pull_request]
 
 jobs:
   check-shellcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-shellcheck.sh
       - run: make shellcheck
   check-shfmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-shfmt.sh
       - run: make shfmtcheck
   verify-query-packages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: ./.github/scripts/verify-query-packages.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,19 +2,19 @@ on: [push, pull_request]
 
 jobs:
   check-shellcheck:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-shellcheck.sh
       - run: make shellcheck
   check-shfmt:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: sudo ./.github/scripts/install-shfmt.sh
       - run: make shfmtcheck
   verify-query-packages:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - run: ./.github/scripts/verify-query-packages.sh


### PR DESCRIPTION
fixing the check which needs to be modified due to https://github.com/delphix/linux-pkg/commit/69ed6915cadb6b0f3d8485f77cc3dcd655da2231

Bonus: fixed the OS that the tests run on to ubuntu-latest since 18.04 is getting depreciated.