### PR TITLE
TOOL-21304 Add support for delphix-go repository to linux-pkg

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -9,6 +9,7 @@ challenge-response
 cloud-init
 crash-python
 crypt-blowfish
+delphix-go
 delphix-platform
 delphix-rust
 delphix-sso-app

--- a/packages/delphix-go/config.sh
+++ b/packages/delphix-go/config.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-go.git"
+
+function build() {
+	logmust mkdir -p "$WORKDIR/repo"
+	logmust dpkg_buildpackage_default
+}

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -17,7 +17,7 @@
 # shellcheck disable=SC2034
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/zfs.git"
-PACKAGE_DEPENDENCIES="@linux-kernel delphix-rust dwarves"
+PACKAGE_DEPENDENCIES="@linux-kernel delphix-rust delphix-go dwarves"
 
 UPSTREAM_GIT_URL="https://github.com/openzfs/zfs.git"
 UPSTREAM_GIT_BRANCH="master"
@@ -56,6 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
+	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }
 


### PR DESCRIPTION
This change introduces the new delphix-go package into the linux-pkg repository so that the go compiler will be installed on dev VMs. It was tested in conjunction with corresponding changes to [appliance-build](url) and [devops-gate](https://github.com/delphix/devops-gate/pull/1124). ab-pre-push was run [here](http://selfservice.pd-jenkins.dcol2.delphix.com/job/appliance-build-orchestrator-pre-push/23/console) and the resulting VM had the GO sdk installed correctly and could be used for zfs builds.