### PR TITLE
DLPX-86188 [Forwardport to 12.0.0.0] - Management service stuck in activating state after deferred upgrade release(10) to develop(12)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -47,7 +47,10 @@ SKIP_COPYRIGHTS_CHECK=true
 function fetch() {
 	logmust cd "$WORKDIR/artifacts"
 
-	local debs=()
+	local debs=(
+		# Copied from https://s3.amazonaws.com/packages.treasuredata.com/4/ubuntu/focal/pool/contrib/t/td-agent/td-agent_4.4.2-1_arm64.deb
+		"td-agent_4.4.2-1_amd64.deb b40c1883c3849e9a7bf67762c9f9a87a6119ad98f1fae64a83d754e1275a379a"
+	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

After upgrading from 10 to 11 when there is an enabled fluentd configuration for a plugin such as [elasticsearch-7.far](https://gitlab.delphix.com/brad.lewis/far-dev/blob/master/elasticsearch-7.far), fluentd and the management stack fail to start.
</details>


<details open>
<summary><h2> Diagnosis </h2></summary>

The fluentd logs show a failure to find a dependency of elasticsearch-7, the gem faraday of major version 1; only version 3.x is available. It turns out that this older gem version, which used to be included in the td-agent package in 10.0 (version [4.4.2-1](https://s3.amazonaws.com/packages.treasuredata.com/4/ubuntu/focal/pool/contrib/t/td-agent/td-agent_4.4.2-1_amd64.deb)) is no longer available in 11.0 (version [4.5.0-1](https://s3.amazonaws.com/packages.treasuredata.com/4/ubuntu/focal/pool/contrib/t/td-agent/td-agent_4.5.0-1_amd64.deb)). The upgrade of td-agent removes that gem, among others. The fluentd container start script copies the gems from td-agent to a new directory, but the stop script deletes that directory, so the old gems are not available anymore.

</details>


<details open>
<summary><h2> Solution </h2></summary>

Until we decide how to deal with plugins that are missing dependencies after upgrading ([DLPX-86157](https://delphix.atlassian.net/browse/DLPX-86157)) and we let the stack start normally even if a plugin fails ([DLPX-86156](https://delphix.atlassian.net/browse/DLPX-86156)), we'll pin td-agent to its version in 10.0 (version [4.4.2-1](https://s3.amazonaws.com/packages.treasuredata.com/4/ubuntu/focal/pool/contrib/t/td-agent/td-agent_4.4.2-1_amd64.deb)).

Specifically, here on linux-pkg, we make sure that this older version of td-agent is available when building the appliance.

Companion app gate review that forces virtualization to depend on this older version: https://github.com/delphix/dlpx-app-gate/pull/728.

</details>


<details close>
<summary><h2> Testing Done </h2></summary>

Provide a clear description of how this change was tested. At minimum
this should include proof that a computer has executed the changed
lines. Ideally this should include an automated test or an explanation
as to why this pull request has no tests.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->