### PR TITLE
TOOL-21469 Allow empty commits when cherry-picking in kernel repos

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -413,7 +413,7 @@ function kernel_merge_with_upstream() {
 	logmust git checkout -q -b repo-HEAD upstream-HEAD
 
 	# shellcheck disable=SC2086
-	logmust git cherry-pick ${dlpx_patch_start}^..${dlpx_patch_end}
+	logmust git cherry-pick --allow-empty ${dlpx_patch_start}^..${dlpx_patch_end}
 
 	logmust touch "$WORKDIR/repo-updated"
 }


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Recently, a merge commit was pushed to the linux-kernel-aws repo
because the author clicked the "Create a merge commit" option to
merge their PR. This caused the `update-package` [jobs](http://ops.jenkins.delphix.com/job/linux-pkg/job/develop/job/update-package/job/linux-kernel-aws/8/console) to fail with:
```
00:14:35.611  error: commit a63f70b93cad58e3b38e0718f2e25663855ffddc is a merge but no -m option was given.
00:14:35.611  fatal: cherry-pick failed
```

To fix this, we decided to fix the git history. But pushing to these repos requires
2 approvals on a PR. To open a PR, we had to create an empty commit. The resulting PR is: https://github.com/delphix/linux-kernel-aws/pull/41

I manually started an update-package job to check if the history rewrite fixes the issue. It failed with:
http://ops.jenkins.delphix.com/job/linux-pkg/job/develop/job/update-package/job/linux-kernel-aws/9/console
```
00:14:33.891  The previous cherry-pick is now empty, possibly due to conflict resolution.
00:14:33.891  If you wish to commit it anyway, use:
00:14:33.891  
00:14:33.891      git commit --allow-empty
00:14:33.891  
00:14:33.891  and then use:
00:14:33.891  
00:14:33.891      git cherry-pick --continue
00:14:33.891  
00:14:33.891  to resume cherry-picking the remaining commits.
00:14:33.891  If you wish to skip this commit, use:
00:14:33.891  
00:14:33.891      git cherry-pick --skip
00:14:33.891  
00:14:33.891  On branch repo-HEAD
00:14:33.891  Cherry-pick currently in progress.
00:14:33.891    (run "git cherry-pick --continue" to continue)
00:14:33.891    (use "git cherry-pick --skip" to skip this patch)
00:14:33.891    (use "git cherry-pick --abort" to cancel the cherry-pick operation)
00:14:33.891  
00:14:33.891  nothing to commit, working tree clean
00:14:33.891  Error: failed command 'git cherry-pick ebaf51ee12c4be20aeaa6fd9b4fcafd61d2f06c6^..24afab62888cb3f09a8e0f1d82fadcf32d452786'
```

This was because cherry-picking an empty commit requires the `--allow-empty` option.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add the `--allow-empty` option. To prevent such issues in the future, I started working on a change
to disallow rebase merges but I am still looking into if this is something that will work for us: https://github.com/delphix/github-infra/pull/615
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

TBA
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
