### PR TITLE
TOOL-21507 linux-pkg should fetch releases from new release dataset paths

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,7 +33,7 @@ function configure_apt_sources() {
 	if [[ -z "$primary_url" ]] || [[ -z "$secondary_url" ]]; then
 		local latest_url="http://linux-package-mirror.delphix.com/"
 		if is_release_branch; then
-			package_mirror_url="${latest_url}${DEFAULT_GIT_BRANCH}"
+			package_mirror_url="${latest_url}releases/${DELPHIX_RELEASE_VERSION}"
 		else
 			latest_url+="${DEFAULT_GIT_BRANCH}/latest/"
 			package_mirror_url=$(curl -LfSs -o /dev/null -w '%{url_effective}' \


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The pregitflow project changed the dataset paths of shipped releases from 
http://linux-package-mirror.delphix.com/release/ to http://linux-package-mirror.delphix.com/releases/.

This caused a regression because the linux-pkg repo used the `DEFAULT_GIT_BRANCH` as the path of the dataset to fetch from because they were both the same `release/A.B.C.D` but now they have changed. The "branches" (tags, really) are still following the old scheme `release/A.B.C.D` but the datasets are not under `releases/A.B.C.D`.

So, I modified the jenkins job in https://github.com/delphix/devops-gate/pull/802 to pass the new scheme to linux-pkg,
and it worked for most build-pkg jobs of shipped releases until now when I tried to ship a hotfix of the azure kernel package: http://selfservice.jenkins.delphix.com/job/linux-pkg/job/custom/job/build-package/job/custom/221/console
```
00:04:06.912  Running: [token passed] git fetch https://github.com/delphix/zfs.git --no-tags +releases/7.0.0.0:repo-HEAD --depth=1
00:04:07.251  fatal: couldn't find remote ref releases/7.0.0.0
```
The reason why this has likely only come to light right now is because the `virtualization` package does not have dependencies that needed to be rebuilt.
```
00:00:23.132  Final build list after applying BUILD_POLICY and REBUILD_DEPENDENCIES policies:
00:00:23.132    [virtualization]
```
vs in my case:
```
00:00:44.823  Final list of packages to build:
00:00:44.823    [linux-kernel-azure, connstat, delphix-kernel, zfs]
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

The fix should be to revert the jenkins job to continue using the true branch scheme `release/A.B.C.D` instead of `releases/A.B.C.D` and modify linux-pkg to not conflate the value to fetch packages from the mirror.
Devops-gate review: https://github.com/delphix/devops-gate/pull/1271
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

http://selfservice.jenkins-palashgandhi.dcol2.delphix.com/job/hotfix-build/14/console
Build a virtualization HF: http://selfservice.jenkins-palashgandhi.dcol2.delphix.com/job/hotfix-build/16/console
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
