### PR TITLE
DLPX-87116 Add cargo license tool to zfs build

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,6 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
+	logmust cargo install cargo-bundle-licenses
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }


### PR DESCRIPTION
### Problem
In order to facilitate keeping our BOM up to date, we need to either update the object agent THIRDPARTYLICENSES file in the repo, or regenerate it at build time. The latter is significantly less development upkeep. This requires that our build environment have the license bundling tool.


### Solution
We add the package to the setup process for building the zfs package.

### Testing Done
ab-pre-push with this and [the related ZFS changes](https://github.com/delphix/zfs/pull/1066): http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6269/console

