### PR TITLE
TOOL-22328 Fix auto-updates for generic kernel on 5.15

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -247,7 +247,7 @@ function kernel_update_upstream() {
 	local tag_prefix_flavour
 	case "${platform}" in
 	generic)
-		if [[ "$UBUNTU_DISTRIBUTION" == bionic ]]; then
+		if [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
 			tag_prefix_flavour="Ubuntu-hwe"
 		else
 			tag_prefix_flavour="Ubuntu"


### PR DESCRIPTION
### Problem

Automated syncs with upstream fail with the following error:
```
04:01:47  Running: get_kernel_version_for_platform_from_apt generic
04:01:47  note: upstream tag prefix used: Ubuntu-5.15-5.15.0-78
04:01:47  tag with prefix Ubuntu-5.15-5.15.0-78 not found.
```
See [here](http://ops.jenkins.delphix.com/job/linux-pkg/job/develop/job/check-updates/job/main/114/consoleFull)

The tags have "hwe" in them, which the automation isn't using due to the bug:
```
> g tag | grep Ubuntu-5.15-5.15.0-78
> g tag | grep Ubuntu-hwe-5.15-5.15.0-78
Ubuntu-hwe-5.15-5.15.0-78.85_20.04.1
```

### Testing

See [here](http://ops.jenkins.delphix.com/job/linux-pkg/job/develop/job/check-updates/job/main/115/console)