### PR TITLE
DLPX-87759 Skip config checks while building the kernel

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -158,10 +158,10 @@ function kernel_build() {
 	#
 	# Here we update the configs used to control the kernel's build
 	# system. This is useful as it allows us to override various
-	# kernel config options via an OVERRIDES file, which we use to
-	# disable varous kernel modules that we don't need or want.
+	# kernel config options via an annotations file, which we use to
+	# disable various kernel modules that we don't need or want.
 	#
-	logmust fakeroot debian/rules updateconfigs "${debian_rules_args[@]}"
+	logmust fakeroot debian/rules updateconfigs "${debian_rules_args[@]}" do_skip_checks=true
 
 	logmust fakeroot debian/rules "binary" "${debian_rules_args[@]}"
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

This is a dependent change required for https://github.com/delphix/linux-kernel-aws/pull/46. Please see the problem statement in that PR for context.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Pass an option to skip the config checks to `updateconfigs`.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

```
[Fri Sep 01, 12:41:49] ~/git/linux-pkg (develop)
 $ git ab-pre-push -b linux-kernel-aws
Running `git push -f origin c8dad4b3b19c5426f860d997acd033222c7c4305:refs/heads/dlpx/test/___develop___/pgandhi-delphix/c8dad4b3b19c5426f860d997acd033222c7c4305`
Your build is at: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/6892/
```
From this build:
```
 Running: fakeroot debian/rules updateconfigs skipdbg=false uefi_signed=false disable_d_i=true do_zfs=false do_dkms_nvidia=false do_dkms_nvidia_server=false do_dkms_vbox=false do_dkms_wireguard=false flavours=aws abinum=1041-dx2023090119-6e87f48dd do_skip_checks=true
 dh_testdir;
...
...
 Skipping config-check (skip_checks=true) ...
 
 Importing all configurations ...
 
 * Import configs for amd64-aws ...
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
