### PR TITLE
TOOL-22968 Integrate mold into linux-pkg repository

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -26,6 +26,7 @@ make-jpkg
 makedumpfile
 masking
 misc-debs
+mold
 nfs-utils
 performance-diagnostics
 ptools

--- a/packages/mold/config.sh
+++ b/packages/mold/config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/mold.git"
+
+UPSTREAM_GIT_URL=https://salsa.debian.org/pkg-llvm-team/mold.git
+UPSTREAM_GIT_BRANCH=master
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
This PR adds the infrastructure to build the mold linker as part of the appliance-build. mold is significantly faster than the default GNU linker, which will improve build times significantly. This change has been tested in conjuction with appliance-build changes, which can be found [here](https://github.com/delphix/appliance-build/pull/738).

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7029/console