### PR TITLE
DLPX-88225 Automated hotfix process leads to hotfix branch engine version always being set as latest engine version TOOL-23229 Improvements to masking/containerized-masking/virtualization linux-pkg handling

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1294,34 +1294,34 @@ function set_secret_build_args() {
 	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
 	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
 
-	if [[ ${SECRET_DB_USE_JUMPBOX+nothing} ]]; then
+	if [ -n "${SECRET_DB_USE_JUMPBOX}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_USE_JUMPBOX=$SECRET_DB_USE_JUMPBOX")
 	fi
 
-	if [[ ${SECRET_DB_JUMP_BOX_HOST+nothing} ]]; then
+	if [ -n "${SECRET_DB_JUMP_BOX_HOST}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_HOST=$SECRET_DB_JUMP_BOX_HOST")
 	fi
 
-	if [[ ${SECRET_DB_JUMP_BOX_USER+nothing} ]]; then
+	if [ -n "${SECRET_DB_JUMP_BOX_USER}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_USER=$SECRET_DB_JUMP_BOX_USER")
 	fi
 
-	if [[ ${SECRET_DB_JUMP_BOX_PRIVATE_KEY+nothing} ]]; then
+	if [ -n "${SECRET_DB_JUMP_BOX_PRIVATE_KEY}" ]; then
 		if [[ ! -f "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
 			die "Jumpbox private key not found."
 		fi
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_PRIVATE_KEY=$SECRET_DB_JUMP_BOX_PRIVATE_KEY")
 	fi
 
-	if [[ ${SECRET_DB_AWS_ENDPOINT+nothing} ]]; then
+	if [ -n "${SECRET_DB_AWS_ENDPOINT}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_ENDPOINT=$SECRET_DB_AWS_ENDPOINT")
 	fi
 
-	if [[ ${SECRET_DB_AWS_PROFILE+nothing} ]]; then
+	if [ -n "${SECRET_DB_AWS_PROFILE}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_PROFILE=$SECRET_DB_AWS_PROFILE")
 	fi
 
-	if [[ ${SECRET_DB_AWS_REGION+nothing} ]]; then
+	if [ -n "${SECRET_DB_AWS_REGION}" ]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_REGION=$SECRET_DB_AWS_REGION")
 	fi
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -17,6 +17,7 @@
 
 export _RET
 export _RET_LIST
+export _SECRET_BUILD_ARGS
 export DEBIAN_FRONTEND=noninteractive
 
 export SUPPORTED_KERNEL_FLAVORS="generic aws gcp azure oracle"
@@ -1280,5 +1281,47 @@ function store_build_info() {
 
 	if [[ -f "$TOP/PACKAGE_MIRROR_URL_SECONDARY" ]]; then
 		logmust cp "$TOP/PACKAGE_MIRROR_URL_SECONDARY" "$WORKDIR/artifacts/"
+	fi
+}
+
+function fetch_secret_build_args() {
+	_SECRET_BUILD_ARGS=()
+
+	# Here we check for whether the environment variables are set and pass them along. We check for
+	# existence instead of emptiness to avoid adding a layer of interpretation.
+
+	# We use parameter expansion in the form of ${variable+nothing} which evaluates to the variable
+	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
+	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
+
+	if [[ ${SECRET_DB_USE_JUMPBOX+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_USE_JUMPBOX=$SECRET_DB_USE_JUMPBOX")
+	fi
+
+	if [[ ${SECRET_DB_JUMP_BOX_HOST+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_HOST=$SECRET_DB_JUMP_BOX_HOST")
+	fi
+
+	if [[ ${SECRET_DB_JUMP_BOX_USER+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_USER=$SECRET_DB_JUMP_BOX_USER")
+	fi
+
+	if [[ ${SECRET_DB_JUMP_BOX_PRIVATE_KEY+nothing} ]]; then
+		if [[ ! -f "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
+			die "Jumpbox private key not found."
+		fi
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_PRIVATE_KEY=$SECRET_DB_JUMP_BOX_PRIVATE_KEY")
+	fi
+
+	if [[ ${SECRET_DB_AWS_ENDPOINT+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_ENDPOINT=$SECRET_DB_AWS_ENDPOINT")
+	fi
+
+	if [[ ${SECRET_DB_AWS_PROFILE+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_PROFILE=$SECRET_DB_AWS_PROFILE")
+	fi
+
+	if [[ ${SECRET_DB_AWS_REGION+nothing} ]]; then
+		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_REGION=$SECRET_DB_AWS_REGION")
 	fi
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1284,7 +1284,7 @@ function store_build_info() {
 	fi
 }
 
-function fetch_secret_build_args() {
+function set_secret_build_args() {
 	_SECRET_BUILD_ARGS=()
 
 	# Here we check for whether the environment variables are set and pass them along. We check for

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1294,34 +1294,34 @@ function set_secret_build_args() {
 	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
 	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
 
-	if [ -n "${SECRET_DB_USE_JUMPBOX}" ]; then
+	if [[ -n "${SECRET_DB_USE_JUMPBOX}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_USE_JUMPBOX=$SECRET_DB_USE_JUMPBOX")
 	fi
 
-	if [ -n "${SECRET_DB_JUMP_BOX_HOST}" ]; then
+	if [[ -n "${SECRET_DB_JUMP_BOX_HOST}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_HOST=$SECRET_DB_JUMP_BOX_HOST")
 	fi
 
-	if [ -n "${SECRET_DB_JUMP_BOX_USER}" ]; then
+	if [[ -n "${SECRET_DB_JUMP_BOX_USER}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_USER=$SECRET_DB_JUMP_BOX_USER")
 	fi
 
-	if [ -n "${SECRET_DB_JUMP_BOX_PRIVATE_KEY}" ]; then
+	if [[ -n "${SECRET_DB_JUMP_BOX_PRIVATE_KEY}" ]]; then
 		if [[ ! -f "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
 			die "Jumpbox private key not found."
 		fi
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_JUMP_BOX_PRIVATE_KEY=$SECRET_DB_JUMP_BOX_PRIVATE_KEY")
 	fi
 
-	if [ -n "${SECRET_DB_AWS_ENDPOINT}" ]; then
+	if [[ -n "${SECRET_DB_AWS_ENDPOINT}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_ENDPOINT=$SECRET_DB_AWS_ENDPOINT")
 	fi
 
-	if [ -n "${SECRET_DB_AWS_PROFILE}" ]; then
+	if [[ -n "${SECRET_DB_AWS_PROFILE}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_PROFILE=$SECRET_DB_AWS_PROFILE")
 	fi
 
-	if [ -n "${SECRET_DB_AWS_REGION}" ]; then
+	if [[ -n "${SECRET_DB_AWS_REGION}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_REGION=$SECRET_DB_AWS_REGION")
 	fi
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1287,13 +1287,6 @@ function store_build_info() {
 function set_secret_build_args() {
 	_SECRET_BUILD_ARGS=()
 
-	# Here we check for whether the environment variables are set and pass them along. We check for
-	# existence instead of emptiness to avoid adding a layer of interpretation.
-
-	# We use parameter expansion in the form of ${variable+nothing} which evaluates to the variable
-	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
-	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
-
 	if [[ -n "${SECRET_DB_USE_JUMPBOX}" ]]; then
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_USE_JUMPBOX=$SECRET_DB_USE_JUMPBOX")
 	fi

--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -45,7 +45,7 @@ function build() {
 
 	local args=()
 
-	fetch_secret_build_args
+	set_secret_build_args
 	args+=("${_SECRET_BUILD_ARGS[@]}")
 
 	args+=("-Porg.gradle.configureondemand=false")

--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -51,7 +51,7 @@ function build() {
 	args+=("-Porg.gradle.configureondemand=false")
 	args+=("-PenvironmentName=linuxappliance")
 
-	if [[ "$DELPHIX_RELEASE_VERSION" ]]; then
+	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
 		args+=("-PmaskingVer=$DELPHIX_RELEASE_VERSION")
 	fi
 

--- a/packages/containerized-masking/config.sh
+++ b/packages/containerized-masking/config.sh
@@ -24,6 +24,9 @@
 # only works with packages that are included in the appliance, which this one
 # isn't.
 #
+
+source "$PWD/lib/common.sh"
+
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dms-core-gate.git"
 
 PACKAGE_DEPENDENCIES="adoptopenjdk"
@@ -40,35 +43,20 @@ function build() {
 
 	logmust cd "$WORKDIR/repo"
 
-	if [[ "$SECRET_DB_AWS_ENDPOINT" ]]; then
-		export SECRET_DB_AWS_ENDPOINT="$SECRET_DB_AWS_ENDPOINT"
-	fi
+	local args=()
 
-	# Using secrets proxy
-	if [[ "$SECRET_DB_USE_JUMPBOX" ]]; then
-		export SECRET_DB_USE_JUMPBOX="$SECRET_DB_USE_JUMPBOX"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_HOST" ]]; then
-		export SECRET_DB_JUMP_BOX_HOST="$SECRET_DB_JUMP_BOX_HOST"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_USER" ]]; then
-		export SECRET_DB_JUMP_BOX_USER="$SECRET_DB_JUMP_BOX_USER"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
-		export SECRET_DB_JUMP_BOX_PRIVATE_KEY="$SECRET_DB_JUMP_BOX_PRIVATE_KEY"
-	fi
+	fetch_secret_build_args
+	args+=("${_SECRET_BUILD_ARGS[@]}")
 
-	# Using master/eng-secret-user
-	if [[ "$SECRET_DB_AWS_PROFILE" ]]; then
-		export SECRET_DB_AWS_PROFILE="$SECRET_DB_AWS_PROFILE"
-	fi
-	if [[ "$SECRET_DB_AWS_REGION" ]]; then
-		export SECRET_DB_AWS_REGION="$SECRET_DB_AWS_REGION"
+	args+=("-Porg.gradle.configureondemand=false")
+	args+=("-PenvironmentName=linuxappliance")
+
+	if [[ "$DELPHIX_RELEASE_VERSION" ]]; then
+		args+=("-PmaskingVer=$DELPHIX_RELEASE_VERSION")
 	fi
 
 	logmust ./gradlew --no-daemon --stacktrace \
-		-Porg.gradle.configureondemand=false \
-		-PenvironmentName=linuxappliance \
+		"${args[@]}" \
 		:tools:docker:packageMaskingKubernetes
 
 	logmust cp -v tools/docker/build/masking-kubernetes*.zip \

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -16,6 +16,8 @@
 #
 # shellcheck disable=SC2034
 
+source "$PWD/lib/common.sh"
+
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dms-core-gate.git"
 PACKAGE_DEPENDENCIES="adoptopenjdk"
 
@@ -43,35 +45,20 @@ function build() {
 		'{ "dms-core-gate" : { "git-hash" : $h, "date": $d }}' \
 		>"$WORKDIR/artifacts/metadata.json"
 
-	if [[ "$SECRET_DB_AWS_ENDPOINT" ]]; then
-		export SECRET_DB_AWS_ENDPOINT="$SECRET_DB_AWS_ENDPOINT"
-	fi
+	local args=()
 
-	# Using secrets proxy
-	if [[ "$SECRET_DB_USE_JUMPBOX" ]]; then
-		export SECRET_DB_USE_JUMPBOX="$SECRET_DB_USE_JUMPBOX"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_HOST" ]]; then
-		export SECRET_DB_JUMP_BOX_HOST="$SECRET_DB_JUMP_BOX_HOST"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_USER" ]]; then
-		export SECRET_DB_JUMP_BOX_USER="$SECRET_DB_JUMP_BOX_USER"
-	fi
-	if [[ "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
-		export SECRET_DB_JUMP_BOX_PRIVATE_KEY="$SECRET_DB_JUMP_BOX_PRIVATE_KEY"
-	fi
+	fetch_secret_build_args
+	args+=("${_SECRET_BUILD_ARGS[@]}")
 
-	# Using master/eng-secret-user
-	if [[ "$SECRET_DB_AWS_PROFILE" ]]; then
-		export SECRET_DB_AWS_PROFILE="$SECRET_DB_AWS_PROFILE"
-	fi
-	if [[ "$SECRET_DB_AWS_REGION" ]]; then
-		export SECRET_DB_AWS_REGION="$SECRET_DB_AWS_REGION"
+	args+=("-Porg.gradle.configureondemand=false")
+	args+=("-PenvironmentName=linuxappliance")
+
+	if [[ "$DELPHIX_RELEASE_VERSION" ]]; then
+		args+=("-PmaskingVer=$DELPHIX_RELEASE_VERSION")
 	fi
 
 	logmust ./gradlew --no-daemon --stacktrace \
-		-Porg.gradle.configureondemand=false \
-		-PenvironmentName=linuxappliance \
+		"${args[@]}" \
 		clean \
 		generateLicenseReport \
 		:dist:distDeb \

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -47,7 +47,7 @@ function build() {
 
 	local args=()
 
-	fetch_secret_build_args
+	set_secret_build_args
 	args+=("${_SECRET_BUILD_ARGS[@]}")
 
 	args+=("-Porg.gradle.configureondemand=false")

--- a/packages/masking/config.sh
+++ b/packages/masking/config.sh
@@ -53,7 +53,7 @@ function build() {
 	args+=("-Porg.gradle.configureondemand=false")
 	args+=("-PenvironmentName=linuxappliance")
 
-	if [[ "$DELPHIX_RELEASE_VERSION" ]]; then
+	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
 		args+=("-PmaskingVer=$DELPHIX_RELEASE_VERSION")
 	fi
 

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -61,7 +61,7 @@ function build() {
 
 	local args=()
 
-	fetch_secret_build_args
+	set_secret_build_args
 	args+=("${_SECRET_BUILD_ARGS[@]}")
 
 	args+=("-Dbuild.branch=$DEFAULT_GIT_BRANCH")

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -16,6 +16,8 @@
 #
 # shellcheck disable=SC2034
 
+source "$PWD/lib/common.sh"
+
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dlpx-app-gate.git"
 PACKAGE_DEPENDENCIES="adoptopenjdk crypt-blowfish host-jdks"
 
@@ -59,45 +61,10 @@ function build() {
 
 	local args=()
 
-	# Here we check for whether the environment variables are set and pass them along. We check for
-	# existence instead of emptiness to avoid adding a layer of interpretation.
-
-	# We use parameter expansion in the form of ${variable+nothing} which evaluates to the variable
-	# 'nothing' if 'variable' is not set. Because 'nothing' is not defined it evaluates to "" when 'variable'
-	# is not set. So [[ "" ]] is what is actually evaluated when 'variable' is not set.
+	fetch_secret_build_args
+	args+=("${_SECRET_BUILD_ARGS[@]}")
 
 	args+=("-Dbuild.branch=$DEFAULT_GIT_BRANCH")
-
-	if [[ ${SECRET_DB_USE_JUMPBOX+nothing} ]]; then
-		args+=("-DSECRET_DB_USE_JUMPBOX=$SECRET_DB_USE_JUMPBOX")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_HOST+nothing} ]]; then
-		args+=("-DSECRET_DB_JUMP_BOX_HOST=$SECRET_DB_JUMP_BOX_HOST")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_USER+nothing} ]]; then
-		args+=("-DSECRET_DB_JUMP_BOX_USER=$SECRET_DB_JUMP_BOX_USER")
-	fi
-
-	if [[ ${SECRET_DB_JUMP_BOX_PRIVATE_KEY+nothing} ]]; then
-		if [[ ! -f "$SECRET_DB_JUMP_BOX_PRIVATE_KEY" ]]; then
-			die "Jumpbox private key not found."
-		fi
-		args+=("-DSECRET_DB_JUMP_BOX_PRIVATE_KEY=$SECRET_DB_JUMP_BOX_PRIVATE_KEY")
-	fi
-
-	if [[ ${SECRET_DB_AWS_ENDPOINT+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_ENDPOINT=$SECRET_DB_AWS_ENDPOINT")
-	fi
-
-	if [[ ${SECRET_DB_AWS_PROFILE+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_PROFILE=$SECRET_DB_AWS_PROFILE")
-	fi
-
-	if [[ ${SECRET_DB_AWS_REGION+nothing} ]]; then
-		args+=("-DSECRET_DB_AWS_REGION=$SECRET_DB_AWS_REGION")
-	fi
 
 	args+=("-Ddockerize=true")
 	args+=("-DbuildJni=true")


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

[DLPX-88225](https://delphix.atlassian.net/browse/DLPX-88225)

The earlier change checked into dms-core-gate at https://github.com/delphix/dms-core-gate/pull/251 unfortunately introduced a slew of issues, including the automated hotfix process not picking up the right engine version for the given hotfix.

[TOOL-23229](https://delphix.atlassian.net/browse/TOOL-23229)

We should reduce repetition when it comes to passing the secret build args needed to fetch secrets from the AWS secret store.
</details>

<details open>
<summary><h2> Solution </h2></summary>

[DLPX-88225](https://delphix.atlassian.net/browse/DLPX-88225)

The environment variable `DELPHIX_RELEASE_VERSION` is what we actually care about - if that's set, we can directly pass it as a gradle property via the gradle command (that way, the dms-core-gate get-branch-version.sh shell script doesn't get executed at all).

[TOOL-23229](https://delphix.atlassian.net/browse/TOOL-23229)

Add a function in `lib/common.sh` that can be used by the virtualization, masking and containerized-masking linux-pkg jobs.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

```
❯ git-ab-pre-push -b "masking virtualization"
Running `git push -f origin fa96e214f6469d599f4e60f4ba343181da9872b3:refs/heads/dlpx/test/___develop___/sonamkindy/fa96e214f6469d599f4e60f4ba343181da9872b3`
Your build is at: http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7291/
```

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/7291/
</details>
