### PR TITLE
DLPX-90375 Azure Linux kernel build failures

### DIFF
--- a/resources/delphix_kernel_annotations
+++ b/resources/delphix_kernel_annotations
@@ -228,5 +228,6 @@ CONFIG_STMMAC_ETH                               policy<{'amd64': 'n', 'arm64': '
 CONFIG_SXGBE_ETH                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_SYNCLINK                                 policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_USB                                      policy<{'amd64': 'n', 'arm64': 'n'}>
+CONFIG_VIDEO_V4L2                               policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_VBOXGUEST                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_VOP                                      policy<{'amd64': 'n', 'arm64': 'n'}>


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The Video for Linux driver is failing to build on Azure kernels.
</details>

<details open>
<summary><h2> Solution </h2></summary>

We don't use this driver, so we can disable its inclusion in the
annotations file.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

http://selfservice.jenkins.delphix.com/job/linux-pkg/job/develop/job/build-package/job/linux-kernel-azure/job/pre-push/49/
</details>
