### PR TITLE
DLPX-90430 Azure kernel build failure in v4l2loopback dkms build

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -127,6 +127,7 @@ function kernel_build() {
 		"do_dkms_nvidia_server=false"
 		"do_dkms_vbox=false"
 		"do_dkms_wireguard=false"
+		"dkms_exclude=v4l2loopback"
 		"flavours=$platform"
 		"abinum=${delphix_abinum}"
 	)

--- a/resources/delphix_kernel_annotations
+++ b/resources/delphix_kernel_annotations
@@ -228,6 +228,5 @@ CONFIG_STMMAC_ETH                               policy<{'amd64': 'n', 'arm64': '
 CONFIG_SXGBE_ETH                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_SYNCLINK                                 policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_USB                                      policy<{'amd64': 'n', 'arm64': 'n'}>
-CONFIG_VIDEO_V4L2                               policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_VBOXGUEST                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_VOP                                      policy<{'amd64': 'n', 'arm64': 'n'}>


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The Linux kernel build for Azure is failing trying to build the
v4l2loopback driver.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Use `dkms_exclude` to prevent this driver from building since we don't
need it. This change also reverts my previous unsuccessful attempt at a
fix.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8165/
</details>
