### PR TITLE
DLPX-90774 - [Backport of DLPX-90116] Upgrade engine JDK to Latest 1.8 - 8u402b06

### DIFF
--- a/packages/adoptopenjdk/config.sh
+++ b/packages/adoptopenjdk/config.sh
@@ -21,13 +21,13 @@ PACKAGE_DEPENDENCIES="make-jpkg"
 
 case $(dpkg-architecture -q DEB_HOST_ARCH 2>/dev/null || echo "none") in
 amd64)
-	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u382b05.tar.gz"
-	_tarfile_sha256="789ad24dc0d9618294e3ba564c9bfda9d3f3a218604350e0ce0381bbc8f28db3"
+	_tarfile="OpenJDK8U-jdk_x64_linux_hotspot_8u402b06.tar.gz"
+	_tarfile_sha256="fcfd08abe39f18e719e391f2fc37b8ac1053075426d10efac4cbf8969e7aa55e"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-amd64"
 	;;
 arm64)
-	_tarfile="OpenJDK8U-jdk_aarch64_linux_hotspot_8u382b05.tar.gz"
-	_tarfile_sha256="0951398197b7bef39ab987b59c22852812ee2c2da6549953eed7fced4c08e13d"
+	_tarfile="OpenJDK8U-jdk_aarch64_linux_hotspot_8u402b06.tar.gz"
+	_tarfile_sha256="241a72d6f0051de30c71e7ade95b34cd85a249c8e5925bcc7a95872bee81fd84"
 	_jdk_path="/usr/lib/jvm/adoptopenjdk-java8-jdk-arm64"
 	;;
 *) ;;


### PR DESCRIPTION
Clean backport of https://github.com/delphix/linux-pkg/pull/312.

linux-pkg build - http://ops.jenkins.delphix.com/job/linux-pkg/job/release/job/build-package/job/adoptopenjdk/job/pre-push/2/ - successful
ab-pre-push - http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/8254/ - successful

Created an engine from the image created above.

```
delphix@ip-10-110-193-46:~$ java -version
openjdk version "1.8.0_402"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_402-b06)
OpenJDK 64-Bit Server VM (Temurin)(build 25.402-b06, mixed mode)
delphix@ip-10-110-193-46:~$ 
```