### PR TITLE
TOOL-25848 add DCT package to linux-pkg

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -9,6 +9,7 @@ challenge-response
 cloud-init
 crash-python
 crypt-blowfish
+dct
 delphix-go
 delphix-platform
 delphix-rust

--- a/packages/dct/config.sh
+++ b/packages/dct/config.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL=none
+SKIP_COPYRIGHTS_CHECK=true
+
+#
+# DCT builds use this URL for storing their artifacts, so we have it hardcoded here.
+#
+DCT_S3_DIR="s3://snapshot-de-images"
+DCT_LATEST_PREFIX="builds/jenkins-ops/dct/develop/post-push/latest"
+
+function fetch() {
+	logmust aws s3 cp "$DCT_S3_DIR/$DCT_LATEST_PREFIX" .
+
+	DCT_PACKAGE_PREFIX=$(cat latest)
+	logmust rm -f latest
+
+	logmust cd artifacts
+	logmust aws s3 sync "$DCT_S3_DIR/$DCT_PACKAGE_PREFIX" .
+	logmust sha256sum -c SHA256SUMS
+}
+
+function build() {
+	return
+	# Nothing to do, all the logic is done in fetch().
+}


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
To support installing the "delphix-dct" package on Delphix engines, we need to have the DCT package available to be installed by the build system.
</details>

<details open>
<summary><h2> Solution </h2></summary>
While the actual building of the DCT package will not be handled by linux-pkg, we're choosing to use linux-pkg to make the pre-built DCT package available to the build system. Thus, the config.sh file for DCT is simply downloading the package from S3, rather than build the package from scratch.
</details>

<details>
<summary><h2> Testing Done </h2></summary>

Used "git-linux-pkg build" to verify the DCT package config.sh works.
```
PACKAGE dct: STAGE fetch STARTED
Running: fetch
Running: aws s3 cp s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/latest .
download: s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/latest to ./latest
Running: rm -f latest
Running: cd artifacts
Running: aws s3 sync s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/1970 .
download: s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/1970/SHA256SUMS to ./SHA256SUMS
download: s3://snapshot-de-images/builds/jenkins-ops/dct/develop/post-push/1970/delphix-dct_20.0.0-1722250787357.7788e36119ec_amd64.deb to ./delphix-dct_20.0.0-1722250787357.7788e36119ec_amd64.deb
Running: sha256sum -c SHA256SUMS
delphix-dct_20.0.0-1722250787357.7788e36119ec_amd64.deb: OK
PACKAGE dct: STAGE fetch COMPLETED in 40 seconds
```
</details>
