### PR TITLE
TOOL-27131 Use --locked flag to force Cargo to use the packaged Cargo.lock file

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,7 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
-	logmust cargo install cargo-bundle-licenses
+	logmust cargo install cargo-bundle-licenses --locked
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }


### PR DESCRIPTION
<summary><h2> Problem </h2></summary>

zfs pre-push runs (and ab-pre-push) have been failing with this:
```
00:44:20  error: failed to compile `cargo-bundle-licenses v2.0.0`, intermediate artifacts can be found at `/tmp/cargo-install8a5GKO`.
00:44:20  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
00:44:20  
00:44:20  Caused by:
00:44:20    rustc 1.80.0 is not supported by the following package:
00:44:20      home@0.5.11 requires rustc 1.81
00:44:20    Try re-running `cargo install` with `--locked`
00:44:20  [1m[31mError: failed command 'cargo install cargo-bundle-licenses'(B[m
```

<summary><h2> Solution </h2></summary>

We need to upgrade rust tools to the latest stable version 1.83.0.
When I attempted that, we ran into a bunch of clippy / checkstyle errors.
https://github.com/delphix/zfs/actions/runs/12379971054/job/34555299344?pr=1955

I am working on fixing them but it is quite invlolved and we need to switch using alternate packages instead of deprecated packages. It looks like it will take a while longer for fix them all. Since this is causing many builds to fail, I would like to get the build to work with the current version of rust. We can do that if we force the use of the version that we specify in our Cargo.lock file (which is not the default behavior) This is done with the [--locked flag](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile)..

See also: https://github.com/delta-io/delta-rs/issues/3065


<summary><h2> Testing Done </h2></summary>

ab-pre-push:
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10081/ PASS
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10083/ PASS
zfs pre-push: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/zfs/job/pre-push/356/console PASS

Manual test:

Failing step passes with `--locked` option.

```
delphix@ip-10-110-195-144:~/zfs/cmd/zfs_object_agent$ cargo install cargo-bundle-licenses
    Updating crates.io index
  Installing cargo-bundle-licenses v2.0.0
    Updating crates.io index
     Locking 93 packages to latest compatible versions
      Adding bitflags v1.3.2 (latest: v2.6.0)
      Adding cargo_metadata v0.15.4 (latest: v0.19.1)
      Adding clap v2.34.0 (latest: v4.5.23)
      Adding env_logger v0.10.2 (latest: v0.11.5)
      Adding heck v0.3.3 (latest: v0.5.0)
      Adding heck v0.4.1 (latest: v0.5.0)
      Adding hermit-abi v0.1.19 (latest: v0.4.0)
      Adding itertools v0.10.5 (latest: v0.13.0)
      Adding strsim v0.8.0 (latest: v0.11.1)
      Adding strum v0.24.1 (latest: v0.26.3)
      Adding strum_macros v0.24.3 (latest: v0.26.4)
      Adding syn v1.0.109 (latest: v2.0.90)
      Adding textwrap v0.11.0 (latest: v0.16.1)
      Adding thiserror v1.0.69 (latest: v2.0.8)
      Adding thiserror-impl v1.0.69 (latest: v2.0.8)
      Adding toml v0.7.8 (latest: v0.8.19)
      Adding toml_edit v0.19.15 (latest: v0.22.22)
      Adding unicode-width v0.1.14 (latest: v0.2.0)
      Adding windows-sys v0.52.0 (latest: v0.59.0)
      Adding winnow v0.5.40 (latest: v0.6.20)
error: failed to compile `cargo-bundle-licenses v2.0.0`, intermediate artifacts can be found at `/tmp/cargo-installGdJBWY`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.80.0 is not supported by the following package:
    home@0.5.11 requires rustc 1.81
  Try re-running `cargo install` with `--locked`
delphix@ip-10-110-195-144:~/zfs/cmd/zfs_object_agent$ cargo install cargo-bundle-licenses --force --locked
    Updating crates.io index
  Installing cargo-bundle-licenses v2.0.0
    Updating crates.io index
warning: package `deunicode v0.4.3` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
warning: package `hermit-abi v0.3.1` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
    Updating crates.io index
   Compiling proc-macro2 v1.0.56
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.26
   Compiling serde_derive v1.0.160
   Compiling serde v1.0.160

<snip>

   Compiling humantime v2.1.0
   Compiling termcolor v1.1.2
   Compiling smallvec v1.8.0
   Compiling spdx v0.10.1
   Compiling env_logger v0.10.0
   Compiling slug v0.1.4
   Compiling structopt v0.3.26
   Compiling itertools v0.10.5
   Compiling serde_yaml v0.9.21
   Compiling cargo_metadata v0.15.4
   Compiling git-version v0.3.5
   Compiling toml v0.7.3
   Compiling strum v0.24.1
   Compiling home v0.5.4
   Compiling cargo-bundle-licenses v2.0.0
    Finished `release` profile [optimized] target(s) in 1m 31s
   Replacing /export/home/delphix/.cargo/bin/cargo-bundle-licenses
    Replaced package `cargo-bundle-licenses v2.0.0` with `cargo-bundle-licenses v2.0.0` (executable `cargo-bundle-licenses`)
warning: be sure to add `/export/home/delphix/.cargo/bin` to your PATH to be able to run the installed binaries
delphix@ip-10-110-195-144:~/zfs/cmd/zfs_object_agent$ cargo install cargo-bundle-licenses --force --locked
```