### PR TITLE
DLPX-93066 zfs package build failed at cargo-bundle-licenses v2.2.0 compile step

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,7 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
-	logmust cargo install cargo-bundle-licenses --locked
+	logmust cargo install cargo-bundle-licenses@2.1.1 --locked
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }


### PR DESCRIPTION
- `git-ab-pre-push -b zfs` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10131/)