### PR TITLE
DLPX-93078 [Backport of DLPX-93066 to release] zfs package build failed at cargo-bundle-licenses v2.2.0 compile step

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,7 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
-	logmust cargo install cargo-bundle-licenses --locked
+	logmust cargo install cargo-bundle-licenses@2.1.1 --locked
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }


### PR DESCRIPTION
Clean cherrypick of: https://www.github.com/delphix/linux-pkg/pull/331