### PR TITLE
DLPX-92948 Upgrade rust tools to 1.84.1

### DIFF
--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,7 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
-	logmust cargo install cargo-bundle-licenses --locked
+	logmust cargo install cargo-bundle-licenses
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -56,7 +56,7 @@ function prepare() {
 		zlib1g-dev
 	logmust install_kernel_headers
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
-	logmust cargo install cargo-bundle-licenses@2.1.1 --locked
+	logmust cargo install cargo-bundle-licenses --locked
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }


### PR DESCRIPTION
Now that we've upgraded to Rust 1.84.1, we don't need the previous workarounds.

- `git-ab-pre-push -b zfs` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/10299/)