### PR TITLE
TOOL-27512 LTS 24.04: Stop using HWE kernels when fetching kernel versions

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1113,21 +1113,13 @@ function get_kernel_version_for_platform_from_apt() {
 	# image for that particular platform. For instance, Ubuntu has a
 	# meta-package for AWS called 'linux-image-aws', which depends on
 	# package 'linux-image-4.15.0-1027-aws'. The latter is the linux image
-	# for kernel version '4.15.0-1027-aws'. We use this depenency to figure
+	# for kernel version '4.15.0-1027-aws'. We use this dependency to figure
 	# out the default kernel version for a given platform.
-	#
-	# The "generic" platform is a special case, since we want to use the
-	# hwe kernel image instead of the regular generic image.
 	#
 	# Note that while the default kernel is usually also the latest
 	# available, it is not always the case.
 	#
-
-	if [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == noble ]]; then
-		package="linux-image-${platform}"
-	else
-		package="linux-image-${platform}-hwe-24.04"
-	fi
+	package="linux-image-${platform}"
 
 	if [[ "$(apt-cache show --no-all-versions "$package" \
 		2>/dev/null | grep Depends)" =~ linux-image-([^,]*-${platform}) ]]; then


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

[check-updates jobs](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/check-updates/job/main/) have been failing since 02/28 while checking updates for linux-kernel-generic with:
```
20:24:56  Running: git remote add upstream https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble
20:24:56  Running: get_kernel_version_for_platform_from_apt generic
20:24:57  note: upstream tag prefix used: Ubuntu-6.11-6.11.0-17
20:24:59  tag with prefix Ubuntu-6.11-6.11.0-17 not found.
20:24:59  trying tag prefix: Ubuntu-6.11.0-17.
20:25:01  Error: could not find upstream tag for tag prefix: Ubuntu-6.11.0-17
```
This logic looks for HWE kernels for the generic flavor and thus tries to use the same version as the HWE flavor. We do not need the HWE flavor.
Also note that all the jobs before 02/28 inferred the kernel version 6.8 for linux-kernel-generic, so this change ensures that we go back to the inferring the same version.

6.11 was released with 24.10. I suspect Canonical made 6.11 available on 24.04 via the HWE image. As to why we no longer need it, we relied on the HWE image as part of the 5.15 kernel upgrade. That was a one-off project, 20.04 shipped with 5.4 but we now wanted 5.15 so we started using HWE. That's no longer the case with 24.04 though, we do not need to jump to 6.11
This is a recent upstream change: https://www.phoronix.com/news/Ubuntu-24.04.2-LTS#:~:text=2%20LTS%20Now%20Available%20With%20Initial%20HWE%20Stack,-Written%20by%20Michael&text=Following%20last%20week's%20delay%20due,04.2%20updates%20too.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Modify the logic to not use the HWE flavor.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/os-upgrade/job/check-updates/job/main/162/console
```
09:17:40  Running: get_kernel_version_for_platform_from_apt generic
09:17:40  note: upstream tag prefix used: Ubuntu-6.8-6.8.0-54
09:17:42  tag with prefix Ubuntu-6.8-6.8.0-54 not found.
09:17:42  trying tag prefix: Ubuntu-6.8.0-54.
09:17:43  Running: git fetch upstream +refs/tags/Ubuntu-6.8.0-54.56:refs/tags/Ubuntu-6.8.0-54.56
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
