### PR TITLE
TOOL-27513 Add FAT and VFAT support for building EFI boot images

### DIFF
--- a/resources/delphix_kernel_annotations
+++ b/resources/delphix_kernel_annotations
@@ -104,7 +104,6 @@ CONFIG_EXFAT_FS                                 policy<{'amd64': 'n', 'arm64': '
 CONFIG_EXT2_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_EXT3_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_F2FS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
-CONFIG_FAT_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_GFS2_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_HFSPLUS_FS                               policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_HFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
@@ -126,7 +125,6 @@ CONFIG_SYSV_FS                                  policy<{'amd64': 'n', 'arm64': '
 CONFIG_UBIFS_FS                                 policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_UDF_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_UFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
-CONFIG_VFAT_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_VXFS_FS                                  policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_XFS_FS                                   policy<{'amd64': 'n', 'arm64': 'n'}>
 


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>
Our os-upgrade buildserver is missing fat/vfat modules which we need to build EFI boot images.


Below is the error from appliance-build-stage1 job
```
10:41:22  + EFI_DIR=/boot/efi
10:41:22  + chroot /mnt/delphix.RfdjBXD mkdir -p /boot/efi
10:41:22  + chroot /mnt/delphix.RfdjBXD mkfs.vfat -F32 /dev/mapper/loop0p3
10:41:23  mkfs.fat 4.2 (2021-01-31)
10:41:23  + chroot /mnt/delphix.RfdjBXD mount /dev/mapper/loop0p3 /boot/efi
10:41:23  mount: /boot/efi: unknown filesystem type 'vfat'.
10:41:23         dmesg(1) may have more information after failed mount system call.
10:41:23  E: config/hooks/90-raw-disk-image.binary failed (exit non-zero). You should check for errors.
10:41:23  P: Begin unmounting filesystems...
10:41:23  P: Saving caches...
10:41:24  Reading package lists...
10:41:24  Building dependency tree...
10:41:24  Reading state information...
10:41:24  + kill -9 17789
10:41:24  + [[ ! -f binary/SHA256SUMS ]]
10:41:24  + exit 1
10:41:25  
10:41:25  > Task :live-build:buildInternalQaEsxVmArtifacts FAILED
10:41:26  
10:41:26  FAILURE: Build failed with an exception.
10:41:26  
10:41:26  * What went wrong:
10:41:26  Execution failed for task ':live-build:buildInternalQaEsxVmArtifacts'.
10:41:26  > Process 'command '/export/home/delphix/jenkins/workspace/appliance-build-stage1/pre-push/appliance-build/scripts/run-live-build.sh'' finished with non-zero exit value 1
```
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-stage1/job/pre-push/49608/consoleFull

The VM kernel does not have fat/vfat modules thus
```
delphix@ip-10-110-229-113:~$ modprobe vfat
modprobe: FATAL: Module vfat not found in directory /lib/modules/6.8.0-1017-dx2025012303-9c92c5173-aws
delphix@ip-10-110-229-113:~$ modinfo vfat
modinfo: ERROR: Module vfat not found.
```
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Include FAT and VFAT filesystem in the Delphix kernel build.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Confirmed VFAT/FAT are included and that creation/mounting vfat filesystem succeed.
```
delphix@ip-10-110-214-171:~$ ARTIFACT_NAME=dummy
delphix@ip-10-110-214-171:~$ truncate -s 10G $ARTIFACT_NAME.img

delphix@ip-10-110-214-171:~$ sgdisk --zap-all "$ARTIFACT_NAME.img"
Creating new GPT entries in memory.
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
GPT data structures destroyed! You may now partition the disk using fdisk or
other utilities.
delphix@ip-10-110-214-171:~$ sgdisk "$ARTIFACT_NAME.img"        --set-alignment=1 --new=2:1m:+1m --typecode=2:EF02
Creating new GPT entries in memory.
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
The operation has completed successfully.
delphix@ip-10-110-214-171:~$ sgdisk "$ARTIFACT_NAME.img"        --new=3::+200m --typecode=3:EF00 -c:3:"EFI Boot"
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
The operation has completed successfully.
delphix@ip-10-110-214-171:~$ sgdisk "$ARTIFACT_NAME.img" --new=1:: --typecode=1:8300
Warning: The kernel is still using the old partition table.
The new table will be used at the next reboot or after you
run partprobe(8) or kpartx(8)
The operation has completed successfully.
delphix@ip-10-110-214-171:~$ sgdisk $ARTIFACT_NAME.img --print
Disk dummy.img: 20971520 sectors, 10.0 GiB
Sector size (logical): 512 bytes
Disk identifier (GUID): 30D3E06E-D2F0-4578-A968-BFD1B3941CB7
Partition table holds up to 128 entries
Main partition table begins at sector 2 and ends at sector 33
First usable sector is 34, last usable sector is 20971486
Partitions will be aligned on 2048-sector boundaries
Total free space is 2014 sectors (1007.0 KiB)

Number  Start (sector)    End (sector)  Size       Code  Name
   1          413696        20971486   9.8 GiB     8300
   2            2048            4095   1024.0 KiB  EF02
   3            4096          413695   200.0 MiB   EF00  EFI Boot
   

delphix@ip-10-110-214-171:~$ sudo kpartx -asv $ARTIFACT_NAME.img
add map loop0p1 (252:0): 0 20557791 linear 7:0 413696
add map loop0p2 (252:1): 0 2048 linear 7:0 2048
add map loop0p3 (252:2): 0 409600 linear 7:0 4096  

delphix@ip-10-110-214-171:~$ sudo fdisk -l /dev/loop0
Disk /dev/loop0: 10 GiB, 10737418240 bytes, 20971520 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 30D3E06E-D2F0-4578-A968-BFD1B3941CB7

Device        Start      End  Sectors  Size Type
/dev/loop0p1 413696 20971486 20557791  9.8G Linux filesystem
/dev/loop0p2   2048     4095     2048    1M BIOS boot
/dev/loop0p3   4096   413695   409600  200M EFI System

delphix@ip-10-110-214-171:~$ sudo mkfs.vfat -F32 /dev/mapper/loop0p3
mkfs.fat 4.2 (2021-01-31)
delphix@ip-10-110-214-171:~$ sudo mount /dev/mapper/loop0p3 /mnt
mount: (hint) your fstab has been modified, but systemd still uses
       the old version; use 'systemctl daemon-reload' to reload.

delphix@ip-10-110-214-171:~$ mount | grep vfat
/dev/mapper/loop0p3 on /mnt type vfat (rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
delphix@ip-10-110-214-171:~$
```
 
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
