### PR TITLE
TOOL-27516 LTS 24.04: Bump os-upgrade version to 9999.0

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,9 +33,7 @@ function configure_apt_sources() {
 	if [[ -z "$primary_url" ]] || [[ -z "$secondary_url" ]]; then
 		local latest_url
 		local delphix_version="$DELPHIX_RELEASE_VERSION"
-		# TODO: Remove the first condition & set the version of os-upgrade in dlpx.version.mapping to
-		#  9999.0.0.0 when https://perforce.atlassian.net/browse/SUP-5179 is done.
-		if compare_versions "$delphix_version" eq "999.0.0.0" || compare_versions "$delphix_version" gt "2025.2"; then
+		if compare_versions "$delphix_version" eq "9999.0.0.0" || compare_versions "$delphix_version" gt "2025.3"; then
 			latest_url="http://linux-package-mirror-v2.delphix.com/"
 		else
 			latest_url="http://linux-package-mirror.delphix.com/"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The version of `os-upgrade` Delphix engines is 999.0.0.0. For upgrade tests to work for the `os-upgrade` branch, the version on the appliance needs to be greater than the new versions (2025.x).
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

I chose 999.0 at the start of the project because we were still on the old versioning scheme and because product keys already existed at the time. Now that 9999.0.0.0 keys have been generated, move the `os-upgrade` branch to 9999.0.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

http://ops.jenkins-palashgandhi.dcol2.delphix.com/job/linux-pkg/job/os-upgrade/job/build-package/job/cloud-init/job/pre-push/1/console
```
21:06:48  Running: configure_apt_sources
21:06:48  Running: sudo rm -rf /etc/apt/sources.list.d
21:06:48  Running: sudo apt-key add /export/home/delphix/jenkins/workspace/linux-pkg/os-upgrade/build-package/cloud-init/pre-push/linux-pkg/resources/delphix-secondary-mirror.key
21:06:48  Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
21:06:48  OK
21:06:48  Running: sudo apt-get update
21:06:49  Hit:1 http://linux-package-mirror-v2.delphix.com/os-upgrade/bcb8a9c1/ubuntu noble InRelease
21:06:49  Hit:2 http://linux-package-mirror-v2.delphix.com/os-upgrade/bcb8a9c1/ubuntu noble-updates InRelease
21:06:49  Hit:3 http://linux-package-mirror-v2.delphix.com/os-upgrade/bcb8a9c1/ubuntu noble-security InRelease
...
...
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
