### PR TITLE
DLPX-93639 LTS 24.04: Upgrade fails due to drgn conflict with upstream python3-drgn package

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -11,6 +11,7 @@ delphix-platform
 delphix-rust
 delphix-sso-app
 docker-python-image
+drgn
 dwarves
 fluentd-gems
 gdb-python

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, 2025 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/drgn.git"
+
+UPSTREAM_GIT_URL="https://github.com/osandov/drgn.git"
+UPSTREAM_GIT_BRANCH="main"
+
+function prepare() {
+	#
+	# Strictly speaking libkdumpfile is not a hard prerequisite for
+	# drgn itself, but it is a hard requirement in our use-case as
+	# we do want to use drgn for kdump-compressed crash dumps.
+	#
+	logmust install_pkgs "$DEPDIR"/libkdumpfile/*.deb
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}

--- a/packages/drgn/config.sh
+++ b/packages/drgn/config.sh
@@ -22,12 +22,6 @@ UPSTREAM_GIT_URL="https://github.com/osandov/drgn.git"
 UPSTREAM_GIT_BRANCH="main"
 
 function prepare() {
-	#
-	# Strictly speaking libkdumpfile is not a hard prerequisite for
-	# drgn itself, but it is a hard requirement in our use-case as
-	# we do want to use drgn for kdump-compressed crash dumps.
-	#
-	logmust install_pkgs "$DEPDIR"/libkdumpfile/*.deb
 	logmust install_build_deps_from_control_file
 }
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade from 20.04 to 24.04 fails due to package name difference of our internal version of the "drgn" package, and ubuntu's package.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution here, is to keep using our internal "drgn" package, rather than ubuntu's.
</details>
