### PR TITLE
DLPX-93685 LTS 24.04: Upgrade fails due to libkdumpfile conflict with upstream libkdumpfile10 package

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -17,6 +17,7 @@ fluentd-gems
 gdb-python
 grub2
 host-jdks
+libkdumpfile
 make-jpkg
 makedumpfile
 masking

--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, 2020 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# shellcheck disable=SC2034
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
+
+UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
+UPSTREAM_GIT_BRANCH="tip"
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
Upgrade from 20.04 to 24.04 fails due to package name difference of our internal version of the "libkdumpfile" package, and ubuntu's package.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution here, is to keep using our internal "libkdumpfile" package, rather than ubuntu's.
</details>
