### PR TITLE
DLPX-94011 simplify kernel build and exclusion of dkms modules

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -46,7 +46,8 @@ function kernel_prepare() {
 		"$DEPDIR"/delphix-rust/*.deb \
 		devscripts \
 		equivs \
-		kernel-wedge
+		kernel-wedge \
+		gawk
 }
 
 #
@@ -123,7 +124,7 @@ function kernel_build() {
 	#   any intention and logic to provide signatures for now
 	#   we set it to false to avoid any misconfigurations down
 	#   the line.
-	# do_dkms_*=false
+	# dkms_exclude=*
 	#   This disables the build of various out-of-tree kernel modules
 	#   that we do not use in our product or that we provide separately.
 	#
@@ -132,12 +133,7 @@ function kernel_build() {
 		"do_tools_common=false"
 		"do_tools_host=false"
 		"uefi_signed=false"
-		"do_zfs=false"
-		"do_dkms_nvidia=false"
-		"do_dkms_nvidia_server=false"
-		"do_dkms_vbox=false"
-		"do_dkms_wireguard=false"
-		"dkms_exclude=v4l2loopback"
+		"dkms_exclude=zfs ipu6 iwlwifi v4l2loopback usbio"
 		"flavours=$platform"
 		"abinum=${delphix_abinum}"
 	)


### PR DESCRIPTION
We currently use a mix of methods to exclude dkms (out of tree) modules from
our kernel builds. In each of the kernel repos, we have removed all of the
lines from `debian.master/dkms-versions` except for the line responsible for
building zfs out of tree. For preventing the zfs build, there is a
`do_zfs=false` `debian/rules` argument set in linux-pkg’s
`default-package-config.sh` script which works for that package.

It would be beneficial to restore the `debian.master/dkms-versions` files to
their original contents, as these are a source of regular merge conflicts.
Instead, we should use the `debian/rules` argument method from linux-pkg, which
can be shared across all linux kernel repos.

Some investigation reveals that there are two ways of excluding a dkms module
from the kernel build via a debian/rules arg:

1. setting `do_<module>=false` (this is how we exclude zfs, by setting
   `do_zfs=false`)
2. by including the module name in a `dkms_exclude=<module list>` argument (this
   is how we were excluding the build of `v4l2loopback` before that line was
   removed entirely from `dkms-versions`)

Using method 2 above is more compact, as all modules we need to exclude can be
included in that one argument. Setting this in linux-pkg will allow us to
restore `dkms-versions` in all of our linux-kernel-* repos and eliminate that
source of merge conflicts.

Once this linux-pkg PR lands, I'll move forward with simplifying our linux-kernel-*
repos.

A secondary problem I noticed in our kernel builds (and this is a problem on develop
as well as on os-upgrade) is that various calls to `debian/rules` are failing because
the gawk command isn't installed. This can be seen in the console output of our various
build-package jobs for the kernel repos. I've fixed that while in here.

# Testing

I'm manually running a kernel build of linux-kernel-generic on an os-upgrade build server
with these linux-pkg changes in place.