### PR TITLE
CP-12470 compile and include the GCP gve (gvnic) driver in our GCP kernels

### DIFF
--- a/resources/delphix_kernel_annotations
+++ b/resources/delphix_kernel_annotations
@@ -156,7 +156,6 @@ CONFIG_ENIC                                     policy<{'amd64': 'n', 'arm64': '
 CONFIG_FM10K                                    policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_FORCEDETH                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_GENWQE                                   policy<{'amd64': 'n', 'arm64': 'n'}>
-CONFIG_GVE                                      policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_HABANA_AI                                policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_HID                                      policy<{'amd64': 'n', 'arm64': 'n'}>
 CONFIG_HIO                                      policy<{'amd64': 'n', 'arm64': 'n'}>


### PR DESCRIPTION
Build and include the gve (gvnic or "Google Virtual NIC") driver in our kernels.

Once this lands, we can discuss how to further validate Google Virtual NIC support for the product (to complete the parent Epic).
