### PR TITLE
CP-12402 linux-pkg Changes: Build Connector using Linux Package Framework

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -30,3 +30,4 @@ savedump
 sdb
 targetcli-fb
 virtualization
+windows-connector

--- a/packages/windows-connector/config.sh
+++ b/packages/windows-connector/config.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dlpx-app-gate.git"
+SKIP_COPYRIGHTS_CHECK=true
+
+function build() {
+	CONNECTOR_DIR="${WORKDIR}/repo/appliance/server/connector"
+	INSTALLER_DIR="${WORKDIR}/repo/appliance/host/windows"
+	logmust cd "$CONNECTOR_DIR"
+	logmust sudo ../../gradlew build
+	logmust cd "$INSTALLER_DIR"
+	logmust sudo ../../gradlew createDebPackage
+	logmust sudo mv ./build/distributions/*deb "$WORKDIR/artifacts/"
+}


### PR DESCRIPTION
**What Have We Achieved?**

With this diff, we have initiated the process of building the Windows connector installer using the Linux package framework.

Specifically, we have built the `.exe` installer and the `dlpxrunas.exe` binary, and included both in the generated Debian package.

**Testing**

This feature was tested by applying the diff in the config.sh, we used:
`PACKAGE_GIT_BRANCH="b0e62290fdc0a254af6212c823009670bcc2a911"`
to point to the specific dlpx-app-gate commit.

**dlpx-app-gate draft diff: https://github.com/delphix/dlpx-app-gate/pull/3252/files**

The build was performed on DCOA using the dlpx-internal-buildserver-develop image.

We verified that the installer was built successfully and that the generated Debian package includes the required .exe files.

<details>

<summary>**Build output**</summary>

```
delphix@ip-10-110-210-165:~/linux-pkg$ ./buildpkg.sh windows-connector
Running: check_running_system
Running: run_setup_if_needed
Running: check_package_exists windows-connector

====================================================================
                     PACKAGE windows-connector
====================================================================

Running: load_package_config windows-connector
Running: check_package_exists windows-connector
Running: reset_package_config_variables
Running: source /export/home/delphix/linux-pkg/default-package-config.sh
Running: source /export/home/delphix/linux-pkg/packages/windows-connector/config.sh
Running: get_package_prefix windows-connector
Running: get_package_config_from_env
get_package_config_from_env(): using prefix: WINDOWS_CONNECTOR_
PACKAGE_GIT_URL set to value of DEFAULT_PACKAGE_GIT_URL
PACKAGE_REVISION set to value of DEFAULT_REVISION
------------------------------------------------------------
PACKAGE_GIT_URL:      https://github.com/delphix/dlpx-app-gate.git
PACKAGE_GIT_BRANCH:   b0e62290fdc0a254af6212c823009670bcc2a911
PACKAGE_REVISION:     delphix.2025.06.16.09.49
------------------------------------------------------------
Running: create_workdir
Running: sudo rm -rf /export/home/delphix/linux-pkg/packages/windows-connector/tmp
Running: mkdir /export/home/delphix/linux-pkg/packages/windows-connector/tmp
Running: rm -f /export/home/delphix/linux-pkg/workdir
Running: ln -s /export/home/delphix/linux-pkg/packages/windows-connector/tmp /export/home/delphix/linux-pkg/workdir
Running: mkdir /export/home/delphix/linux-pkg/packages/windows-connector/tmp/artifacts
Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: STAGE fetch STARTED
Running: fetch
Running: fetch_repo_from_git
Running: mkdir /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo
Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo
Running: git init
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
Initialized empty Git repository in /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/.git/
Running: git_fetch_helper https://github.com/delphix/dlpx-app-gate.git --no-tags +b0e62290fdc0a254af6212c823009670bcc2a911:repo-HEAD --depth=1
Running:  git fetch https://github.com/delphix/dlpx-app-gate.git --no-tags +b0e62290fdc0a254af6212c823009670bcc2a911:repo-HEAD --depth=1
Username for 'https://github.com': vimlesh.mishra@gmail.com
Password for 'https://vimlesh.mishra%40gmail.com@github.com': 
remote: Enumerating objects: 21476, done.
remote: Counting objects: 100% (21476/21476), done.
remote: Compressing objects: 100% (17021/17021), done.
remote: Total 21476 (delta 4472), reused 11601 (delta 2352), pack-reused 0 (from 0)
Receiving objects: 100% (21476/21476), 111.53 MiB | 29.58 MiB/s, done.
Resolving deltas: 100% (4472/4472), done.
From https://github.com/delphix/dlpx-app-gate
 * [new ref]           b0e62290fdc0a254af6212c823009670bcc2a911 -> repo-HEAD
Running: git show-ref repo-HEAD
b0e62290fdc0a254af6212c823009670bcc2a911 refs/heads/repo-HEAD
Running: git checkout repo-HEAD
Updating files: 100% (17004/17004), done.
Switched to branch 'repo-HEAD'
PACKAGE windows-connector: STAGE fetch COMPLETED in 31 seconds

Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: STAGE fetch_dependencies STARTED
Running: fetch_dependencies s3
Running: mkdir /export/home/delphix/linux-pkg/packages/windows-connector/tmp/dependencies
Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp/dependencies
Package has no linux-pkg dependencies to fetch.
PACKAGE windows-connector: STAGE fetch_dependencies COMPLETED in 0 seconds

Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: SKIPPING UNDEFINED STAGE prepare

Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: STAGE build STARTED
Running: build
Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/server/connector
Running: sudo ../../gradlew build
Downloading http://artifactory.delphix.com/artifactory/maven-private/gradle-distributions/gradle-7.6.4-bin.zip
.....................................................................................................................

Welcome to Gradle 7.6.4!

Here are the highlights of this release:
 - Added support for Java 19.
 - Introduced `--rerun` flag for individual task rerun.
 - Improved dependency block for test suites to be strongly typed.
 - Added a pluggable system for Java toolchains provisioning.

For more details see https://docs.gradle.org/7.6.4/release-notes.html

To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6.4/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 
Configuration on demand is an incubating feature.

> Configure project :
Directory created successfully: /export/home/delphix/tmp
Directory created successfully: /export/home/testrunner/tmp

> Task :server:connector:dxosTest

com.delphix.appliance.server.connector.test.ConnectorClientTest > doFileTest STARTED

com.delphix.appliance.server.connector.test.ConnectorClientTest > doFileTest PASSED

com.delphix.appliance.server.connector.test.ConnectorClientTest > doGetConnectionsTest STARTED

com.delphix.appliance.server.connector.test.ConnectorClientTest > doGetConnectionsTest PASSED

com.delphix.appliance.server.connector.test.ConnectorClientTest > doExecTest STARTED

com.delphix.appliance.server.connector.test.ConnectorClientTest > doExecTest PASSED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4m 38s
67 actionable tasks: 67 executed
Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows
Running: sudo ../../gradlew createDebPackage
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6.4/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 
Configuration on demand is an incubating feature.

> Task :host:windows:buildDelphixConnectorService
Reading package lists...
Building dependency tree...G [58s]
Reading state information... [58s]
binutils-common is already the newest version (2.42-4ubuntu2.5).
binutils-common set to manually installed.
binutils-x86-64-linux-gnu is already the newest version (2.42-4ubuntu2.5).
binutils-x86-64-linux-gnu set to manually installed.
binutils is already the newest version (2.42-4ubuntu2.5).
binutils set to manually installed.
ca-certificates is already the newest version (20240203).
ca-certificates set to manually installed.
debconf is already the newest version (1.5.86ubuntu1).
fontconfig-config is already the newest version (2.15.0-1.1ubuntu2).
fontconfig-config set to manually installed.
fonts-dejavu-core is already the newest version (2.37-8).
fonts-dejavu-core set to manually installed.
fonts-dejavu-mono is already the newest version (2.37-8).
fonts-dejavu-mono set to manually installed.
gcc-14-base is already the newest version (14.2.0-4ubuntu2~24.04).
libbinutils is already the newest version (2.42-4ubuntu2.5).
libbinutils set to manually installed.
libblkid1 is already the newest version (2.39.3-9ubuntu6.2).
libbrotli1 is already the newest version (1.1.0-2build2).
libbrotli1 set to manually installed.
libbsd0 is already the newest version (0.12.1-1build1.1).
libbsd0 set to manually installed.
libbz2-1.0 is already the newest version (1.0.8-5.1build0.1).
libc6 is already the newest version (2.39-0ubuntu8.4).
libcom-err2 is already the newest version (1.47.0-2.4~exp1ubuntu4.1).
libctf-nobfd0 is already the newest version (2.42-4ubuntu2.5).
libctf-nobfd0 set to manually installed.
libctf0 is already the newest version (2.42-4ubuntu2.5).
libctf0 set to manually installed.
libdeflate0 is already the newest version (1.19-1build1.1).
libdeflate0 set to manually installed.
libexpat1 is already the newest version (2.6.1-2ubuntu0.3).
libexpat1 set to manually installed.
libffi8 is already the newest version (3.4.6-1build1).
libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
libfontconfig1 set to manually installed.
libfreetype6 is already the newest version (2.13.2+dfsg-1build3).
libfreetype6 set to manually installed.
libgcc-s1 is already the newest version (14.2.0-4ubuntu2~24.04).
libgprofng0 is already the newest version (2.42-4ubuntu2.5).
libgprofng0 set to manually installed.
libjansson4 is already the newest version (2.14-2build2).
libjansson4 set to manually installed.
libjbig0 is already the newest version (2.1-6.1ubuntu2).
libjbig0 set to manually installed.
libjpeg-turbo8 is already the newest version (2.1.5-2ubuntu2).
libjpeg-turbo8 set to manually installed.
libjpeg8 is already the newest version (8c-2ubuntu11).
libjpeg8 set to manually installed.
libkeyutils1 is already the newest version (1.6.3-3build1).
libkeyutils1 set to manually installed.
liblerc4 is already the newest version (4.0.0+ds-4ubuntu2).
liblerc4 set to manually installed.
liblzma5 is already the newest version (5.6.1+really5.4.5-1ubuntu0.2).
libmd0 is already the newest version (1.1.0-2build1.1).
libmount1 is already the newest version (2.39.3-9ubuntu6.2).
libpcre2-8-0 is already the newest version (10.42-4ubuntu2.1).
libpng16-16t64 is already the newest version (1.6.43-5build1).
libpng16-16t64 set to manually installed.
libreadline8t64 is already the newest version (8.2-4build1).
libreadline8t64 set to manually installed.
libselinux1 is already the newest version (3.5-2ubuntu2.1).
libsframe1 is already the newest version (2.42-4ubuntu2.5).
libsframe1 set to manually installed.
libsharpyuv0 is already the newest version (1.3.2-0.4build3).
libsharpyuv0 set to manually installed.
libslang2 is already the newest version (2.3.3-3build2).
libslang2 set to manually installed.
libssl3t64 is already the newest version (3.0.13-0ubuntu3.5).
libstdc++6 is already the newest version (14.2.0-4ubuntu2~24.04).
libtiff6 is already the newest version (4.5.1+git230720-4ubuntu2.2).
libtiff6 set to manually installed.
libtinfo6 is already the newest version (6.4+20240113-1ubuntu2).
libwebp7 is already the newest version (1.3.2-0.4build3).
libwebp7 set to manually installed.
libx11-6 is already the newest version (2:1.8.7-1build1).
libx11-6 set to manually installed.
libx11-data is already the newest version (2:1.8.7-1build1).
libx11-data set to manually installed.
libxau6 is already the newest version (1:1.0.9-1build6).
libxau6 set to manually installed.
libxcb1 is already the newest version (1.15-1ubuntu2).
libxcb1 set to manually installed.
libxdmcp6 is already the newest version (1:1.1.3-0ubuntu6).
libxdmcp6 set to manually installed.
libxext6 is already the newest version (2:1.3.4-1build2).
libxext6 set to manually installed.
libxrender1 is already the newest version (1:0.9.10-1.1build1).
libxrender1 set to manually installed.
libzstd1 is already the newest version (1.5.5+dfsg2-2build1.1).
openssl is already the newest version (3.0.13-0ubuntu3.5).
openssl set to manually installed.
readline-common is already the newest version (8.2-4build1).
readline-common set to manually installed.
sysvinit-utils is already the newest version (3.08-6ubuntu3).
x11-common is already the newest version (1:7.7+23ubuntu3).
x11-common set to manually installed.
zlib1g is already the newest version (1:1.3.dfsg-3.1ubuntu2.1).
Suggested packages:
  cdebconf-gtk fonts-crosextra-caladea fonts-crosextra-carlito
  low-memory-monitor krb5-doc krb5-user libgnomeui-0 libgtk2.0-0 librsvg2-2
  shared-mime-info libasound2 libgamin0 xdg-utils | libgnome2-0 | konqueror
Recommended packages:
  fonts-liberation-sans-narrow fonts-texgyre-math libglib2.0-data
  shared-mime-info xdg-user-dirs krb5-locales libmono-btls-interface4.0-cil
  libgluezilla cli-common mono-csharp-shell binfmt-support
The following NEW packages will be installed:
  ca-certificates-mono cdebconf fontconfig fonts-croscore fonts-freefont-otf
  fonts-freefont-ttf fonts-liberation fonts-noto-core fonts-noto-mono
  fonts-texgyre fonts-urw-base35 libcairo2 libdatrie1 libdebian-installer4
  libexif12 libfontenc1 libfribidi0 libgdiplus libgif7 libgraphite2-3
  libharfbuzz0b libmono-2.0-dev libmono-accessibility4.0-cil
  libmono-cairo4.0-cil libmono-cecil-private-cil libmono-cil-dev
  libmono-codecontracts4.0-cil libmono-compilerservices-symbolwriter4.0-cil
  libmono-corlib4.5-cil libmono-corlib4.5-dll libmono-cscompmgd0.0-cil
  libmono-csharp4.0c-cil libmono-custommarshalers4.0-cil
  libmono-data-tds4.0-cil libmono-db2-1.0-cil libmono-debugger-soft4.0a-cil
  libmono-http4.0-cil libmono-i18n-cjk4.0-cil libmono-i18n-mideast4.0-cil
  libmono-i18n-other4.0-cil libmono-i18n-rare4.0-cil libmono-i18n-west4.0-cil
  libmono-i18n4.0-all libmono-i18n4.0-cil libmono-ldap4.0-cil
  libmono-management4.0-cil libmono-messaging-rabbitmq4.0-cil
  libmono-messaging4.0-cil libmono-microsoft-build-engine4.0-cil
  libmono-microsoft-build-framework4.0-cil
  libmono-microsoft-build-tasks-v4.0-4.0-cil
  libmono-microsoft-build-utilities-v4.0-4.0-cil
  libmono-microsoft-build4.0-cil libmono-microsoft-csharp4.0-cil
  libmono-microsoft-visualc10.0-cil
  libmono-microsoft-web-infrastructure1.0-cil libmono-oracle4.0-cil
  libmono-parallel4.0-cil libmono-peapi4.0a-cil libmono-posix4.0-cil
  libmono-rabbitmq4.0-cil libmono-relaxng4.0-cil libmono-security4.0-cil
  libmono-sharpzip4.84-cil libmono-simd4.0-cil libmono-smdiagnostics0.0-cil
  libmono-sqlite4.0-cil libmono-system-componentmodel-composition4.0-cil
  libmono-system-componentmodel-dataannotations4.0-cil
  libmono-system-configuration-install4.0-cil
  libmono-system-configuration4.0-cil libmono-system-core4.0-cil
  libmono-system-data-datasetextensions4.0-cil
  libmono-system-data-entity4.0-cil libmono-system-data-linq4.0-cil
  libmono-system-data-services-client4.0-cil
  libmono-system-data-services4.0-cil libmono-system-data4.0-cil
  libmono-system-deployment4.0-cil libmono-system-design4.0-cil
  libmono-system-drawing-design4.0-cil libmono-system-drawing4.0-cil
  libmono-system-dynamic4.0-cil libmono-system-enterpriseservices4.0-cil
  libmono-system-identitymodel-selectors4.0-cil
  libmono-system-identitymodel4.0-cil
  libmono-system-io-compression-filesystem4.0-cil
  libmono-system-io-compression4.0-cil libmono-system-json-microsoft4.0-cil
  libmono-system-json4.0-cil libmono-system-ldap-protocols4.0-cil
  libmono-system-ldap4.0-cil libmono-system-management4.0-cil
  libmono-system-messaging4.0-cil libmono-system-net-http-formatting4.0-cil
  libmono-system-net-http-webrequest4.0-cil libmono-system-net-http4.0-cil
  libmono-system-net4.0-cil libmono-system-numerics-vectors4.0-cil
  libmono-system-numerics4.0-cil libmono-system-reactive-core2.2-cil
  libmono-system-reactive-debugger2.2-cil
  libmono-system-reactive-experimental2.2-cil
  libmono-system-reactive-interfaces2.2-cil
  libmono-system-reactive-linq2.2-cil
  libmono-system-reactive-observable-aliases0.0-cil
  libmono-system-reactive-platformservices2.2-cil
  libmono-system-reactive-providers2.2-cil
  libmono-system-reactive-runtime-remoting2.2-cil
  libmono-system-reactive-windows-forms2.2-cil
  libmono-system-reactive-windows-threading2.2-cil
  libmono-system-reflection-context4.0-cil
  libmono-system-runtime-caching4.0-cil
  libmono-system-runtime-durableinstancing4.0-cil
  libmono-system-runtime-serialization-formatters-soap4.0-cil
  libmono-system-runtime-serialization4.0-cil libmono-system-runtime4.0-cil
  libmono-system-security4.0-cil libmono-system-servicemodel-activation4.0-cil
  libmono-system-servicemodel-discovery4.0-cil
  libmono-system-servicemodel-internals0.0-cil
  libmono-system-servicemodel-routing4.0-cil
  libmono-system-servicemodel-web4.0-cil libmono-system-servicemodel4.0a-cil
  libmono-system-serviceprocess4.0-cil
  libmono-system-threading-tasks-dataflow4.0-cil
  libmono-system-transactions4.0-cil libmono-system-web-abstractions4.0-cil
  libmono-system-web-applicationservices4.0-cil
  libmono-system-web-dynamicdata4.0-cil
  libmono-system-web-extensions-design4.0-cil
  libmono-system-web-extensions4.0-cil libmono-system-web-http-selfhost4.0-cil
  libmono-system-web-http-webhost4.0-cil libmono-system-web-http4.0-cil
  libmono-system-web-mobile4.0-cil libmono-system-web-mvc3.0-cil
  libmono-system-web-razor2.0-cil libmono-system-web-regularexpressions4.0-cil
  libmono-system-web-routing4.0-cil libmono-system-web-services4.0-cil
  libmono-system-web-webpages-deployment2.0-cil
  libmono-system-web-webpages-razor2.0-cil libmono-system-web-webpages2.0-cil
  libmono-system-web4.0-cil
  libmono-system-windows-forms-datavisualization4.0a-cil
  libmono-system-windows-forms4.0-cil libmono-system-windows4.0-cil
  libmono-system-workflow-activities4.0-cil
  libmono-system-workflow-componentmodel4.0-cil
  libmono-system-workflow-runtime4.0-cil libmono-system-xaml4.0-cil
  libmono-system-xml-linq4.0-cil libmono-system-xml-serialization4.0-cil
  libmono-system-xml4.0-cil libmono-system4.0-cil libmono-tasklets4.0-cil
  libmono-webbrowser4.0-cil libmono-webmatrix-data4.0-cil
  libmono-windowsbase4.0-cil libmono-xbuild-tasks4.0-cil libmonosgen-2.0-1
  libmonosgen-2.0-dev libnewt0.52 libpango-1.0-0 libpangocairo-1.0-0
  libpangoft2-1.0-0 libpixman-1-0 libpkgconf3 libtextwrap1 libthai-data
  libthai0 libxcb-render0 libxcb-shm0 lsb-base mono-4.0-gac mono-devel
  mono-gac mono-mcs mono-runtime mono-runtime-common mono-runtime-sgen
  mono-xbuild pkg-config pkgconf pkgconf-bin xfonts-encodings xfonts-utils
The following packages will be upgraded:
  libglib2.0-0t64 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0
  libsqlite3-0 tzdata
7 upgraded, 188 newly installed, 0 to remove and 31 not upgraded.
Need to get 105 MB of archives.
After this operation, 321 MB of additional disk space will be used.
Get:1 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libgssapi-krb5-2 amd64 1.20.1-6ubuntu2.6 [143 kB]
Get:2 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libkrb5-3 amd64 1.20.1-6ubuntu2.6 [348 kB]
Get:3 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libkrb5support0 amd64 1.20.1-6ubuntu2.6 [34.4 kB]
Get:4 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libk5crypto3 amd64 1.20.1-6ubuntu2.6 [82.0 kB]
Get:5 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-runtime-common amd64 6.8.0.105+dfsg-3.6ubuntu2 [1085 kB]
Get:6 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libdebian-installer4 amd64 0.124ubuntu2 [26.3 kB]
Get:7 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libnewt0.52 amd64 0.52.24-2ubuntu2 [46.8 kB]
Get:8 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libtextwrap1 amd64 0.1-17build1 [9468 B]
Get:9 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 cdebconf amd64 0.271ubuntu3 [145 kB]
Get:10 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 tzdata all 2025b-0ubuntu0.24.04.1 [276 kB]
Get:11 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-corlib4.5-dll all 6.8.0.105+dfsg-3.6ubuntu2 [1392 kB]
Get:12 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-core4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [342 kB]
Get:13 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-numerics4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [53.3 kB]
Get:14 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-xml4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [910 kB]
Get:15 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-security4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [125 kB]
Get:16 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-configuration4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [60.4 kB]
Get:17 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [902 kB]
Get:18 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-security4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [106 kB]
Get:19 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-4.0-gac all 6.8.0.105+dfsg-3.6ubuntu2 [174 kB]
Get:20 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-gac all 6.8.0.105+dfsg-3.6ubuntu2 [19.4 kB]
Get:21 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-runtime-sgen amd64 6.8.0.105+dfsg-3.6ubuntu2 [1934 kB]
Get:22 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-runtime amd64 6.8.0.105+dfsg-3.6ubuntu2 [15.2 kB]
Get:23 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-corlib4.5-cil all 6.8.0.105+dfsg-3.6ubuntu2 [13.2 kB]
Get:24 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 ca-certificates-mono all 6.8.0.105+dfsg-3.6ubuntu2 [18.9 kB]
Get:25 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libfribidi0 amd64 1.0.13-3build1 [26.1 kB]
Get:26 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libglib2.0-0t64 amd64 2.80.0-6ubuntu3.4 [1544 kB]
Get:27 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble-updates/main amd64 libsqlite3-0 amd64 3.45.1-1ubuntu2.3 [701 kB]
Get:28 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fontconfig amd64 2.15.0-1.1ubuntu2 [180 kB]
Get:29 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 fonts-croscore all 20201225-2 [1709 kB]
Get:30 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 fonts-freefont-otf all 20211204+svn4273-2 [4596 kB]
Get:31 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
Get:32 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fonts-liberation all 1:2.1.5-3 [1603 kB]
Get:33 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fonts-noto-mono all 20201225-2 [435 kB]
Get:34 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fonts-noto-core all 20201225-2 [13.3 MB]
Get:35 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 fonts-texgyre all 20180621-6 [8350 kB]
Get:36 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libfontenc1 amd64 1:1.1.8-1build1 [14.0 kB]
Get:37 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
Get:38 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
Get:39 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 fonts-urw-base35 all 20200910-8 [11.0 MB]
Get:40 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libpixman-1-0 amd64 0.42.2-1build1 [279 kB]
Get:41 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libxcb-render0 amd64 1.15-1ubuntu2 [16.2 kB]
Get:42 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libxcb-shm0 amd64 1.15-1ubuntu2 [5756 B]
Get:43 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libcairo2 amd64 1.18.0-3build1 [566 kB]
Get:44 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libdatrie1 amd64 0.2.13-3build1 [19.0 kB]
Get:45 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libexif12 amd64 0.6.24-1build2 [87.9 kB]
Get:46 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libgif7 amd64 5.2.2-1ubuntu1 [35.2 kB]
Get:47 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libgraphite2-3 amd64 1.3.14-2build1 [73.0 kB]
Get:48 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libharfbuzz0b amd64 8.3.0-2build2 [469 kB]
Get:49 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libthai-data all 0.1.29-2build1 [158 kB]
Get:50 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libthai0 amd64 0.1.29-2build1 [18.9 kB]
Get:51 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libpango-1.0-0 amd64 1.52.1+ds-1build1 [231 kB]
Get:52 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libpangoft2-1.0-0 amd64 1.52.1+ds-1build1 [42.5 kB]
Get:53 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libpangocairo-1.0-0 amd64 1.52.1+ds-1build1 [28.8 kB]
Get:54 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libgdiplus amd64 6.1+dfsg-1build3 [180 kB]
Get:55 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmonosgen-2.0-1 amd64 6.8.0.105+dfsg-3.6ubuntu2 [1866 kB]
Get:56 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmonosgen-2.0-dev amd64 6.8.0.105+dfsg-3.6ubuntu2 [2166 kB]
Get:57 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-2.0-dev amd64 6.8.0.105+dfsg-3.6ubuntu2 [50.2 kB]
Get:58 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-accessibility4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.6 kB]
Get:59 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-cairo4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [35.2 kB]
Get:60 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-cecil-private-cil all 6.8.0.105+dfsg-3.6ubuntu2 [230 kB]
Get:61 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-codecontracts4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [229 kB]
Get:62 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-compilerservices-symbolwriter4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [30.5 kB]
Get:63 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-cscompmgd0.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [19.5 kB]
Get:64 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-csharp4.0c-cil all 6.8.0.105+dfsg-3.6ubuntu2 [449 kB]
Get:65 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-custommarshalers4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [17.2 kB]
Get:66 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-data-tds4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [50.2 kB]
Get:67 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-transactions4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [25.2 kB]
Get:68 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-enterpriseservices4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [29.5 kB]
Get:69 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [643 kB]
Get:70 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-db2-1.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [40.0 kB]
Get:71 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-debugger-soft4.0a-cil all 6.8.0.105+dfsg-3.6ubuntu2 [75.9 kB]
Get:72 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-sharpzip4.84-cil all 6.8.0.105+dfsg-3.6ubuntu2 [66.0 kB]
Get:73 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-sqlite4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [63.5 kB]
Get:74 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-componentmodel-dataannotations4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [40.5 kB]
Get:75 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-drawing4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [174 kB]
Get:76 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-runtime-serialization-formatters-soap4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [28.7 kB]
Get:77 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-applicationservices4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.5 kB]
Get:78 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-posix4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [92.9 kB]
Get:79 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-webbrowser4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [65.6 kB]
Get:80 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.4 kB]
Get:81 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n-west4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [28.5 kB]
Get:82 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-windows-forms4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [918 kB]
Get:83 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-design4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [116 kB]
Get:84 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-ldap4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [103 kB]
Get:85 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-ldap4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [46.6 kB]
Get:86 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-services4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [190 kB]
Get:87 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [847 kB]
Get:88 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-http4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.1 kB]
Get:89 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n-cjk4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [275 kB]
Get:90 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n-mideast4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [21.5 kB]
Get:91 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n-other4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [22.9 kB]
Get:92 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n-rare4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [44.2 kB]
Get:93 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-i18n4.0-all all 6.8.0.105+dfsg-3.6ubuntu2 [12.7 kB]
Get:94 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-management4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [17.6 kB]
Get:95 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-messaging4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [25.5 kB]
Get:96 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-rabbitmq4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [118 kB]
Get:97 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-messaging-rabbitmq4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [25.9 kB]
Get:98 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-build-framework4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [23.7 kB]
Get:99 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-build4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [114 kB]
Get:100 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-build-utilities-v4.0-4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [34.9 kB]
Get:101 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-build-engine4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [99.9 kB]
Get:102 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-xbuild-tasks4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [27.8 kB]
Get:103 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-build-tasks-v4.0-4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [78.1 kB]
Get:104 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-csharp4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [129 kB]
Get:105 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-visualc10.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.0 kB]
Get:106 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-microsoft-web-infrastructure1.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [18.7 kB]
Get:107 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-oracle4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [71.7 kB]
Get:108 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-parallel4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.7 kB]
Get:109 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-peapi4.0a-cil all 6.8.0.105+dfsg-3.6ubuntu2 [52.7 kB]
Get:110 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-relaxng4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [89.8 kB]
Get:111 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-simd4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [30.6 kB]
Get:112 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel-internals0.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [90.9 kB]
Get:113 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-smdiagnostics0.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [30.0 kB]
Get:114 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-componentmodel-composition4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [107 kB]
Get:115 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-configuration-install4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [21.2 kB]
Get:116 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data-datasetextensions4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [23.9 kB]
Get:117 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-runtime-serialization4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [278 kB]
Get:118 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-xml-linq4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [62.9 kB]
Get:119 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data-entity4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [937 kB]
Get:120 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data-linq4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [223 kB]
Get:121 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data-services-client4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [155 kB]
Get:122 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-identitymodel4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [60.4 kB]
Get:123 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-identitymodel-selectors4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [18.2 kB]
Get:124 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-messaging4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [39.8 kB]
Get:125 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel4.0a-cil all 6.8.0.105+dfsg-3.6ubuntu2 [431 kB]
Get:126 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel-activation4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.9 kB]
Get:127 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-extensions4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [176 kB]
Get:128 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel-web4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [44.2 kB]
Get:129 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-data-services4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [31.1 kB]
Get:130 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-deployment4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.9 kB]
Get:131 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-drawing-design4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [23.9 kB]
Get:132 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-dynamic4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [48.5 kB]
Get:133 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-io-compression4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [61.1 kB]
Get:134 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-io-compression-filesystem4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [19.3 kB]
Get:135 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-json4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.5 kB]
Get:136 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-json-microsoft4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [34.4 kB]
Get:137 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-ldap-protocols4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [34.5 kB]
Get:138 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-management4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [29.6 kB]
Get:139 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-net4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.8 kB]
Get:140 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-net-http4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [121 kB]
Get:141 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-net-http-formatting4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [195 kB]
Get:142 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-net-http-webrequest4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [23.3 kB]
Get:143 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-numerics-vectors4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.2 kB]
Get:144 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-interfaces2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.1 kB]
Get:145 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-core2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [51.5 kB]
Get:146 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-linq2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [192 kB]
Get:147 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-debugger2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.0 kB]
Get:148 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-experimental2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [24.1 kB]
Get:149 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-providers2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [60.0 kB]
Get:150 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-observable-aliases0.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.1 kB]
Get:151 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-platformservices2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [23.2 kB]
Get:152 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-runtime-remoting2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.9 kB]
Get:153 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-windows-forms2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [17.0 kB]
Get:154 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-xaml4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [83.1 kB]
Get:155 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-windowsbase4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [72.5 kB]
Get:156 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reactive-windows-threading2.2-cil all 6.8.0.105+dfsg-3.6ubuntu2 [18.3 kB]
Get:157 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-reflection-context4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.6 kB]
Get:158 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-runtime4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [61.0 kB]
Get:159 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-runtime-caching4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [42.1 kB]
Get:160 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-runtime-durableinstancing4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [50.8 kB]
Get:161 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel-discovery4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [59.1 kB]
Get:162 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-servicemodel-routing4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [25.0 kB]
Get:163 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-serviceprocess4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [30.9 kB]
Get:164 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-threading-tasks-dataflow4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [77.4 kB]
Get:165 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-abstractions4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.3 kB]
Get:166 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-dynamicdata4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [40.5 kB]
Get:167 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-extensions-design4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [17.3 kB]
Get:168 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-http4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [136 kB]
Get:169 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-http-selfhost4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [48.7 kB]
Get:170 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-http-webhost4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [37.7 kB]
Get:171 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-mobile4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.9 kB]
Get:172 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-razor2.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [107 kB]
Get:173 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-webpages-deployment2.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [28.2 kB]
Get:174 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-webpages2.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [87.4 kB]
Get:175 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-webpages-razor2.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [27.5 kB]
Get:176 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-mvc3.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [161 kB]
Get:177 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-regularexpressions4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.0 kB]
Get:178 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-web-routing4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.2 kB]
Get:179 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-windows4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.9 kB]
Get:180 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-windows-forms-datavisualization4.0a-cil all 6.8.0.105+dfsg-3.6ubuntu2 [59.0 kB]
Get:181 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-workflow-activities4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.0 kB]
Get:182 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-workflow-componentmodel4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.0 kB]
Get:183 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-workflow-runtime4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.9 kB]
Get:184 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-system-xml-serialization4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [15.8 kB]
Get:185 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-tasklets4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [16.3 kB]
Get:186 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-webmatrix-data4.0-cil all 6.8.0.105+dfsg-3.6ubuntu2 [19.4 kB]
Get:187 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 libmono-cil-dev all 6.8.0.105+dfsg-3.6ubuntu2 [15.3 kB]
Get:188 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 libpkgconf3 amd64 1.8.1-2build1 [30.7 kB]
Get:189 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 lsb-base all 11.6 [4606 B]
Get:190 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-mcs all 6.8.0.105+dfsg-3.6ubuntu2 [596 kB]
Get:191 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-xbuild all 6.8.0.105+dfsg-3.6ubuntu2 [514 kB]
Get:192 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 pkgconf-bin amd64 1.8.1-2build1 [20.7 kB]
Get:193 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 pkgconf amd64 1.8.1-2build1 [16.8 kB]
Get:194 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/main amd64 pkg-config amd64 1.8.1-2build1 [7264 B]
Get:195 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mono-devel all 6.8.0.105+dfsg-3.6ubuntu2 [28.5 MB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 105 MB in 1s (72.0 MB/s)
(Reading database ... 145735 files and directories currently installed.)
Preparing to unpack .../0-libgssapi-krb5-2_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.20.1-6ubuntu2.6) over (1.20.1-6ubuntu2.5) ...
Preparing to unpack .../1-libkrb5-3_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.20.1-6ubuntu2.6) over (1.20.1-6ubuntu2.5) ...
Preparing to unpack .../2-libkrb5support0_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.20.1-6ubuntu2.6) over (1.20.1-6ubuntu2.5) ...
Preparing to unpack .../3-libk5crypto3_1.20.1-6ubuntu2.6_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.20.1-6ubuntu2.6) over (1.20.1-6ubuntu2.5) ...
Selecting previously unselected package mono-runtime-common.
Preparing to unpack .../4-mono-runtime-common_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking mono-runtime-common (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libdebian-installer4:amd64.
Preparing to unpack .../5-libdebian-installer4_0.124ubuntu2_amd64.deb ...
Unpacking libdebian-installer4:amd64 (0.124ubuntu2) ...
Setting up libdebian-installer4:amd64 (0.124ubuntu2) ...
Selecting previously unselected package libnewt0.52:amd64.
(Reading database ... 145789 files and directories currently installed.)
Preparing to unpack .../libnewt0.52_0.52.24-2ubuntu2_amd64.deb ...
Unpacking libnewt0.52:amd64 (0.52.24-2ubuntu2) ...
Setting up libnewt0.52:amd64 (0.52.24-2ubuntu2) ...
update-alternatives: using /etc/newt/palette.ubuntu to provide /etc/newt/palette (newt-palette) in auto mode
Selecting previously unselected package libtextwrap1:amd64.
(Reading database ... 145797 files and directories currently installed.)
Preparing to unpack .../libtextwrap1_0.1-17build1_amd64.deb ...
Unpacking libtextwrap1:amd64 (0.1-17build1) ...
Setting up libtextwrap1:amd64 (0.1-17build1) ...
Selecting previously unselected package cdebconf.
(Reading database ... 145803 files and directories currently installed.)
Preparing to unpack .../cdebconf_0.271ubuntu3_amd64.deb ...
Unpacking cdebconf (0.271ubuntu3) ...Service
Setting up cdebconf (0.271ubuntu3) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
(Reading database ... 145843 files and directories currently installed.)
Preparing to unpack .../0-tzdata_2025b-0ubuntu0.24.04.1_all.deb ...
Unpacking tzdata (2025b-0ubuntu0.24.04.1) over (2025b-0ubuntu0.24.04) ...
Selecting previously unselected package libmono-corlib4.5-dll.
Preparing to unpack .../1-libmono-corlib4.5-dll_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-corlib4.5-dll (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-core4.0-cil.
Preparing to unpack .../2-libmono-system-core4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-core4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-numerics4.0-cil.
Preparing to unpack .../3-libmono-system-numerics4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-numerics4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-xml4.0-cil.
Preparing to unpack .../4-libmono-system-xml4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-xml4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-security4.0-cil.
Preparing to unpack .../5-libmono-system-security4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-security4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-configuration4.0-cil.
Preparing to unpack .../6-libmono-system-configuration4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-configuration4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system4.0-cil.
Preparing to unpack .../7-libmono-system4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-security4.0-cil.
Preparing to unpack .../8-libmono-security4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-security4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package mono-4.0-gac.
Preparing to unpack .../9-mono-4.0-gac_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking mono-4.0-gac (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libkrb5support0:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libk5crypto3:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libkrb5-3:amd64 (1.20.1-6ubuntu2.6) ...
Setting up libgssapi-krb5-2:amd64 (1.20.1-6ubuntu2.6) ...
Setting up mono-runtime-common (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package mono-gac.
(Reading database ... 145905 files and directories currently installed.)
Preparing to unpack .../000-mono-gac_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking mono-gac (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package mono-runtime-sgen.
Preparing to unpack .../001-mono-runtime-sgen_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking mono-runtime-sgen (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package mono-runtime.
Preparing to unpack .../002-mono-runtime_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking mono-runtime (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-corlib4.5-cil.
Preparing to unpack .../003-libmono-corlib4.5-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-corlib4.5-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package ca-certificates-mono.
Preparing to unpack .../004-ca-certificates-mono_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking ca-certificates-mono (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libfribidi0:amd64.
Preparing to unpack .../005-libfribidi0_1.0.13-3build1_amd64.deb ...
Unpacking libfribidi0:amd64 (1.0.13-3build1) ...
Preparing to unpack .../006-libglib2.0-0t64_2.80.0-6ubuntu3.4_amd64.deb ...
Unpacking libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.4) over (2.80.0-6ubuntu3.2) ...
Preparing to unpack .../007-libsqlite3-0_3.45.1-1ubuntu2.3_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.45.1-1ubuntu2.3) over (3.45.1-1ubuntu2.1) ...
Selecting previously unselected package fontconfig.
Preparing to unpack .../008-fontconfig_2.15.0-1.1ubuntu2_amd64.deb ...
Unpacking fontconfig (2.15.0-1.1ubuntu2) ...
Selecting previously unselected package fonts-croscore.
Preparing to unpack .../009-fonts-croscore_20201225-2_all.deb ...
Unpacking fonts-croscore (20201225-2) ...
Selecting previously unselected package fonts-freefont-otf.
Preparing to unpack .../010-fonts-freefont-otf_20211204+svn4273-2_all.deb ...
Unpacking fonts-freefont-otf (20211204+svn4273-2) ...
Selecting previously unselected package fonts-freefont-ttf.
Preparing to unpack .../011-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
Selecting previously unselected package fonts-liberation.
Preparing to unpack .../012-fonts-liberation_1%3a2.1.5-3_all.deb ...
Unpacking fonts-liberation (1:2.1.5-3) ...
Selecting previously unselected package fonts-noto-mono.
Preparing to unpack .../013-fonts-noto-mono_20201225-2_all.deb ...
Unpacking fonts-noto-mono (20201225-2) ...
Selecting previously unselected package fonts-noto-core.
Preparing to unpack .../014-fonts-noto-core_20201225-2_all.deb ...
Unpacking fonts-noto-core (20201225-2) ...
Selecting previously unselected package fonts-texgyre.
Preparing to unpack .../015-fonts-texgyre_20180621-6_all.deb ...
Unpacking fonts-texgyre (20180621-6) ...
Selecting previously unselected package libfontenc1:amd64.
Preparing to unpack .../016-libfontenc1_1%3a1.1.8-1build1_amd64.deb ...
Unpacking libfontenc1:amd64 (1:1.1.8-1build1) ...
Selecting previously unselected package xfonts-encodings.
Preparing to unpack .../017-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
Selecting previously unselected package xfonts-utils.
Preparing to unpack .../018-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
Unpacking xfonts-utils (1:7.7+6build3) ...
Selecting previously unselected package fonts-urw-base35.
Preparing to unpack .../019-fonts-urw-base35_20200910-8_all.deb ...
Unpacking fonts-urw-base35 (20200910-8) ...
Selecting previously unselected package libpixman-1-0:amd64.
Preparing to unpack .../020-libpixman-1-0_0.42.2-1build1_amd64.deb ...
Unpacking libpixman-1-0:amd64 (0.42.2-1build1) ...
Selecting previously unselected package libxcb-render0:amd64.
Preparing to unpack .../021-libxcb-render0_1.15-1ubuntu2_amd64.deb ...
Unpacking libxcb-render0:amd64 (1.15-1ubuntu2) ...
Selecting previously unselected package libxcb-shm0:amd64.
Preparing to unpack .../022-libxcb-shm0_1.15-1ubuntu2_amd64.deb ...
Unpacking libxcb-shm0:amd64 (1.15-1ubuntu2) ...
Selecting previously unselected package libcairo2:amd64.
Preparing to unpack .../023-libcairo2_1.18.0-3build1_amd64.deb ...
Unpacking libcairo2:amd64 (1.18.0-3build1) ...
Selecting previously unselected package libdatrie1:amd64.
Preparing to unpack .../024-libdatrie1_0.2.13-3build1_amd64.deb ...
Unpacking libdatrie1:amd64 (0.2.13-3build1) ...
Selecting previously unselected package libexif12:amd64.
Preparing to unpack .../025-libexif12_0.6.24-1build2_amd64.deb ...
Unpacking libexif12:amd64 (0.6.24-1build2) ...
Selecting previously unselected package libgif7:amd64.
Preparing to unpack .../026-libgif7_5.2.2-1ubuntu1_amd64.deb ...
Unpacking libgif7:amd64 (5.2.2-1ubuntu1) ...
Selecting previously unselected package libgraphite2-3:amd64.
Preparing to unpack .../027-libgraphite2-3_1.3.14-2build1_amd64.deb ...
Unpacking libgraphite2-3:amd64 (1.3.14-2build1) ...
Selecting previously unselected package libharfbuzz0b:amd64.
Preparing to unpack .../028-libharfbuzz0b_8.3.0-2build2_amd64.deb ...
Unpacking libharfbuzz0b:amd64 (8.3.0-2build2) ...
Selecting previously unselected package libthai-data.
Preparing to unpack .../029-libthai-data_0.1.29-2build1_all.deb ...
Unpacking libthai-data (0.1.29-2build1) ...
Selecting previously unselected package libthai0:amd64.
Preparing to unpack .../030-libthai0_0.1.29-2build1_amd64.deb ...
Unpacking libthai0:amd64 (0.1.29-2build1) ...
Selecting previously unselected package libpango-1.0-0:amd64.
Preparing to unpack .../031-libpango-1.0-0_1.52.1+ds-1build1_amd64.deb ...
Unpacking libpango-1.0-0:amd64 (1.52.1+ds-1build1) ...
Selecting previously unselected package libpangoft2-1.0-0:amd64.
Preparing to unpack .../032-libpangoft2-1.0-0_1.52.1+ds-1build1_amd64.deb ...
Unpacking libpangoft2-1.0-0:amd64 (1.52.1+ds-1build1) ...
Selecting previously unselected package libpangocairo-1.0-0:amd64.
Preparing to unpack .../033-libpangocairo-1.0-0_1.52.1+ds-1build1_amd64.deb ...
Unpacking libpangocairo-1.0-0:amd64 (1.52.1+ds-1build1) ...
Selecting previously unselected package libgdiplus.
Preparing to unpack .../034-libgdiplus_6.1+dfsg-1build3_amd64.deb ...
Unpacking libgdiplus (6.1+dfsg-1build3) ...
Selecting previously unselected package libmonosgen-2.0-1.
Preparing to unpack .../035-libmonosgen-2.0-1_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking libmonosgen-2.0-1 (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmonosgen-2.0-dev.
Preparing to unpack .../036-libmonosgen-2.0-dev_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking libmonosgen-2.0-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-2.0-dev.
Preparing to unpack .../037-libmono-2.0-dev_6.8.0.105+dfsg-3.6ubuntu2_amd64.deb ...
Unpacking libmono-2.0-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-accessibility4.0-cil.
Preparing to unpack .../038-libmono-accessibility4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-accessibility4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-cairo4.0-cil.
Preparing to unpack .../039-libmono-cairo4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-cairo4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-cecil-private-cil.
Preparing to unpack .../040-libmono-cecil-private-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-cecil-private-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-codecontracts4.0-cil.
Preparing to unpack .../041-libmono-codecontracts4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-codecontracts4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-compilerservices-symbolwriter4.0-cil.
Preparing to unpack .../042-libmono-compilerservices-symbolwriter4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-compilerservices-symbolwriter4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-cscompmgd0.0-cil.
Preparing to unpack .../043-libmono-cscompmgd0.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-cscompmgd0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-csharp4.0c-cil.
Preparing to unpack .../044-libmono-csharp4.0c-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-csharp4.0c-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-custommarshalers4.0-cil.
Preparing to unpack .../045-libmono-custommarshalers4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-custommarshalers4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-data-tds4.0-cil.
Preparing to unpack .../046-libmono-data-tds4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-data-tds4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-transactions4.0-cil.
Preparing to unpack .../047-libmono-system-transactions4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-transactions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-enterpriseservices4.0-cil.
Preparing to unpack .../048-libmono-system-enterpriseservices4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-enterpriseservices4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data4.0-cil.
Preparing to unpack .../049-libmono-system-data4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-db2-1.0-cil.
Preparing to unpack .../050-libmono-db2-1.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-db2-1.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-debugger-soft4.0a-cil.
Preparing to unpack .../051-libmono-debugger-soft4.0a-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-debugger-soft4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-sharpzip4.84-cil.
Preparing to unpack .../052-libmono-sharpzip4.84-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-sharpzip4.84-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-sqlite4.0-cil.
Preparing to unpack .../053-libmono-sqlite4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-sqlite4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-componentmodel-dataannotations4.0-cil.
Preparing to unpack .../054-libmono-system-componentmodel-dataannotations4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-componentmodel-dataannotations4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-drawing4.0-cil.
Preparing to unpack .../055-libmono-system-drawing4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-drawing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-runtime-serialization-formatters-soap4.0-cil.
Preparing to unpack .../056-libmono-system-runtime-serialization-formatters-soap4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-runtime-serialization-formatters-soap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-applicationservices4.0-cil.
Preparing to unpack .../057-libmono-system-web-applicationservices4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-applicationservices4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-posix4.0-cil.
Preparing to unpack .../058-libmono-posix4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-posix4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-webbrowser4.0-cil.
Preparing to unpack .../059-libmono-webbrowser4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-webbrowser4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n4.0-cil.
Preparing to unpack .../060-libmono-i18n4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n-west4.0-cil.
Preparing to unpack .../061-libmono-i18n-west4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n-west4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-windows-forms4.0-cil.
Preparing to unpack .../062-libmono-system-windows-forms4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-windows-forms4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-design4.0-cil.
Preparing to unpack .../063-libmono-system-design4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-ldap4.0-cil.
Preparing to unpack .../064-libmono-ldap4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-ldap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-ldap4.0-cil.
Preparing to unpack .../065-libmono-system-ldap4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-ldap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-services4.0-cil.
Preparing to unpack .../066-libmono-system-web-services4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-services4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web4.0-cil.
Preparing to unpack .../067-libmono-system-web4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-http4.0-cil.
Preparing to unpack .../068-libmono-http4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n-cjk4.0-cil.
Preparing to unpack .../069-libmono-i18n-cjk4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n-cjk4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n-mideast4.0-cil.
Preparing to unpack .../070-libmono-i18n-mideast4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n-mideast4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n-other4.0-cil.
Preparing to unpack .../071-libmono-i18n-other4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n-other4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n-rare4.0-cil.
Preparing to unpack .../072-libmono-i18n-rare4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n-rare4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-i18n4.0-all.
Preparing to unpack .../073-libmono-i18n4.0-all_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-i18n4.0-all (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-management4.0-cil.
Preparing to unpack .../074-libmono-management4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-management4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-messaging4.0-cil.
Preparing to unpack .../075-libmono-messaging4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-messaging4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-rabbitmq4.0-cil.
Preparing to unpack .../076-libmono-rabbitmq4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-rabbitmq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-messaging-rabbitmq4.0-cil.
Preparing to unpack .../077-libmono-messaging-rabbitmq4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-messaging-rabbitmq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-build-framework4.0-cil.
Preparing to unpack .../078-libmono-microsoft-build-framework4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-build-framework4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-build4.0-cil.
Preparing to unpack .../079-libmono-microsoft-build4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-build4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-build-utilities-v4.0-4.0-cil.
Preparing to unpack .../080-libmono-microsoft-build-utilities-v4.0-4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-build-utilities-v4.0-4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-build-engine4.0-cil.
Preparing to unpack .../081-libmono-microsoft-build-engine4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-build-engine4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-xbuild-tasks4.0-cil.
Preparing to unpack .../082-libmono-xbuild-tasks4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-xbuild-tasks4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-build-tasks-v4.0-4.0-cil.
Preparing to unpack .../083-libmono-microsoft-build-tasks-v4.0-4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-build-tasks-v4.0-4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-csharp4.0-cil.
Preparing to unpack .../084-libmono-microsoft-csharp4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-csharp4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-visualc10.0-cil.
Preparing to unpack .../085-libmono-microsoft-visualc10.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-visualc10.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-microsoft-web-infrastructure1.0-cil.
Preparing to unpack .../086-libmono-microsoft-web-infrastructure1.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-microsoft-web-infrastructure1.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-oracle4.0-cil.
Preparing to unpack .../087-libmono-oracle4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-oracle4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-parallel4.0-cil.
Preparing to unpack .../088-libmono-parallel4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-parallel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-peapi4.0a-cil.
Preparing to unpack .../089-libmono-peapi4.0a-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-peapi4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-relaxng4.0-cil.
Preparing to unpack .../090-libmono-relaxng4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-relaxng4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-simd4.0-cil.
Preparing to unpack .../091-libmono-simd4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-simd4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel-internals0.0-cil.
Preparing to unpack .../092-libmono-system-servicemodel-internals0.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel-internals0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-smdiagnostics0.0-cil.
Preparing to unpack .../093-libmono-smdiagnostics0.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-smdiagnostics0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-componentmodel-composition4.0-cil.
Preparing to unpack .../094-libmono-system-componentmodel-composition4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-componentmodel-composition4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-configuration-install4.0-cil.
Preparing to unpack .../095-libmono-system-configuration-install4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-configuration-install4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data-datasetextensions4.0-cil.
Preparing to unpack .../096-libmono-system-data-datasetextensions4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data-datasetextensions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-runtime-serialization4.0-cil.
Preparing to unpack .../097-libmono-system-runtime-serialization4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-runtime-serialization4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-xml-linq4.0-cil.
Preparing to unpack .../098-libmono-system-xml-linq4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-xml-linq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data-entity4.0-cil.
Preparing to unpack .../099-libmono-system-data-entity4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data-entity4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data-linq4.0-cil.
Preparing to unpack .../100-libmono-system-data-linq4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data-linq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data-services-client4.0-cil.
Preparing to unpack .../101-libmono-system-data-services-client4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data-services-client4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-identitymodel4.0-cil.
Preparing to unpack .../102-libmono-system-identitymodel4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-identitymodel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-identitymodel-selectors4.0-cil.
Preparing to unpack .../103-libmono-system-identitymodel-selectors4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-identitymodel-selectors4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-messaging4.0-cil.
Preparing to unpack .../104-libmono-system-messaging4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-messaging4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel4.0a-cil.
Preparing to unpack .../105-libmono-system-servicemodel4.0a-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel-activation4.0-cil.
Preparing to unpack .../106-libmono-system-servicemodel-activation4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel-activation4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-extensions4.0-cil.
Preparing to unpack .../107-libmono-system-web-extensions4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-extensions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel-web4.0-cil.
Preparing to unpack .../108-libmono-system-servicemodel-web4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel-web4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-data-services4.0-cil.
Preparing to unpack .../109-libmono-system-data-services4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-data-services4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-deployment4.0-cil.
Preparing to unpack .../110-libmono-system-deployment4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-deployment4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-drawing-design4.0-cil.
Preparing to unpack .../111-libmono-system-drawing-design4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-drawing-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-dynamic4.0-cil.
Preparing to unpack .../112-libmono-system-dynamic4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-dynamic4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-io-compression4.0-cil.
Preparing to unpack .../113-libmono-system-io-compression4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-io-compression4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-io-compression-filesystem4.0-cil.
Preparing to unpack .../114-libmono-system-io-compression-filesystem4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-io-compression-filesystem4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-json4.0-cil.
Preparing to unpack .../115-libmono-system-json4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-json4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-json-microsoft4.0-cil.
Preparing to unpack .../116-libmono-system-json-microsoft4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-json-microsoft4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-ldap-protocols4.0-cil.
Preparing to unpack .../117-libmono-system-ldap-protocols4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-ldap-protocols4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-management4.0-cil.
Preparing to unpack .../118-libmono-system-management4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-management4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-net4.0-cil.
Preparing to unpack .../119-libmono-system-net4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-net4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-net-http4.0-cil.
Preparing to unpack .../120-libmono-system-net-http4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-net-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-net-http-formatting4.0-cil.
Preparing to unpack .../121-libmono-system-net-http-formatting4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-net-http-formatting4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-net-http-webrequest4.0-cil.
Preparing to unpack .../122-libmono-system-net-http-webrequest4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-net-http-webrequest4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-numerics-vectors4.0-cil.
Preparing to unpack .../123-libmono-system-numerics-vectors4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-numerics-vectors4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-interfaces2.2-cil.
Preparing to unpack .../124-libmono-system-reactive-interfaces2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-interfaces2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-core2.2-cil.
Preparing to unpack .../125-libmono-system-reactive-core2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-core2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-linq2.2-cil.
Preparing to unpack .../126-libmono-system-reactive-linq2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-linq2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-debugger2.2-cil.
Preparing to unpack .../127-libmono-system-reactive-debugger2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-debugger2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-experimental2.2-cil.
Preparing to unpack .../128-libmono-system-reactive-experimental2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-experimental2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-providers2.2-cil.
Preparing to unpack .../129-libmono-system-reactive-providers2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-providers2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-observable-aliases0.0-cil.
Preparing to unpack .../130-libmono-system-reactive-observable-aliases0.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-observable-aliases0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-platformservices2.2-cil.
Preparing to unpack .../131-libmono-system-reactive-platformservices2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-platformservices2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-runtime-remoting2.2-cil.
Preparing to unpack .../132-libmono-system-reactive-runtime-remoting2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-runtime-remoting2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-windows-forms2.2-cil.
Preparing to unpack .../133-libmono-system-reactive-windows-forms2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-windows-forms2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-xaml4.0-cil.
Preparing to unpack .../134-libmono-system-xaml4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-xaml4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-windowsbase4.0-cil.
Preparing to unpack .../135-libmono-windowsbase4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-windowsbase4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reactive-windows-threading2.2-cil.
Preparing to unpack .../136-libmono-system-reactive-windows-threading2.2-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reactive-windows-threading2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-reflection-context4.0-cil.
Preparing to unpack .../137-libmono-system-reflection-context4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-reflection-context4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-runtime4.0-cil.
Preparing to unpack .../138-libmono-system-runtime4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-runtime4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-runtime-caching4.0-cil.
Preparing to unpack .../139-libmono-system-runtime-caching4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-runtime-caching4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-runtime-durableinstancing4.0-cil.
Preparing to unpack .../140-libmono-system-runtime-durableinstancing4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-runtime-durableinstancing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel-discovery4.0-cil.
Preparing to unpack .../141-libmono-system-servicemodel-discovery4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel-discovery4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-servicemodel-routing4.0-cil.
Preparing to unpack .../142-libmono-system-servicemodel-routing4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-servicemodel-routing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-serviceprocess4.0-cil.
Preparing to unpack .../143-libmono-system-serviceprocess4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-serviceprocess4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-threading-tasks-dataflow4.0-cil.
Preparing to unpack .../144-libmono-system-threading-tasks-dataflow4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-threading-tasks-dataflow4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-abstractions4.0-cil.
Preparing to unpack .../145-libmono-system-web-abstractions4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-abstractions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-dynamicdata4.0-cil.
Preparing to unpack .../146-libmono-system-web-dynamicdata4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-dynamicdata4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-extensions-design4.0-cil.
Preparing to unpack .../147-libmono-system-web-extensions-design4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-extensions-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-http4.0-cil.
Preparing to unpack .../148-libmono-system-web-http4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-http-selfhost4.0-cil.
Preparing to unpack .../149-libmono-system-web-http-selfhost4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-http-selfhost4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-http-webhost4.0-cil.
Preparing to unpack .../150-libmono-system-web-http-webhost4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-http-webhost4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-mobile4.0-cil.
Preparing to unpack .../151-libmono-system-web-mobile4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-mobile4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-razor2.0-cil.
Preparing to unpack .../152-libmono-system-web-razor2.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-razor2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-webpages-deployment2.0-cil.
Preparing to unpack .../153-libmono-system-web-webpages-deployment2.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-webpages-deployment2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-webpages2.0-cil.
Preparing to unpack .../154-libmono-system-web-webpages2.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-webpages2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-webpages-razor2.0-cil.
Preparing to unpack .../155-libmono-system-web-webpages-razor2.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-webpages-razor2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-mvc3.0-cil.
Preparing to unpack .../156-libmono-system-web-mvc3.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-mvc3.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-regularexpressions4.0-cil.
Preparing to unpack .../157-libmono-system-web-regularexpressions4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-regularexpressions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-web-routing4.0-cil.
Preparing to unpack .../158-libmono-system-web-routing4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-web-routing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-windows4.0-cil.
Preparing to unpack .../159-libmono-system-windows4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-windows4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-windows-forms-datavisualization4.0a-cil.
Preparing to unpack .../160-libmono-system-windows-forms-datavisualization4.0a-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-windows-forms-datavisualization4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-workflow-activities4.0-cil.
Preparing to unpack .../161-libmono-system-workflow-activities4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-workflow-activities4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-workflow-componentmodel4.0-cil.
Preparing to unpack .../162-libmono-system-workflow-componentmodel4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-workflow-componentmodel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-workflow-runtime4.0-cil.
Preparing to unpack .../163-libmono-system-workflow-runtime4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-workflow-runtime4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-system-xml-serialization4.0-cil.
Preparing to unpack .../164-libmono-system-xml-serialization4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-system-xml-serialization4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-tasklets4.0-cil.
Preparing to unpack .../165-libmono-tasklets4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-tasklets4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-webmatrix-data4.0-cil.
Preparing to unpack .../166-libmono-webmatrix-data4.0-cil_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-webmatrix-data4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libmono-cil-dev.
Preparing to unpack .../167-libmono-cil-dev_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking libmono-cil-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package libpkgconf3:amd64.
Preparing to unpack .../168-libpkgconf3_1.8.1-2build1_amd64.deb ...
Unpacking libpkgconf3:amd64 (1.8.1-2build1) ...
Selecting previously unselected package lsb-base.
Preparing to unpack .../169-lsb-base_11.6_all.deb ...
Unpacking lsb-base (11.6) ...
Selecting previously unselected package mono-mcs.
Preparing to unpack .../170-mono-mcs_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking mono-mcs (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package mono-xbuild.
Preparing to unpack .../171-mono-xbuild_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking mono-xbuild (6.8.0.105+dfsg-3.6ubuntu2) ...
Selecting previously unselected package pkgconf-bin.
Preparing to unpack .../172-pkgconf-bin_1.8.1-2build1_amd64.deb ...
Unpacking pkgconf-bin (1.8.1-2build1) ...
Selecting previously unselected package pkgconf:amd64.
Preparing to unpack .../173-pkgconf_1.8.1-2build1_amd64.deb ...
Unpacking pkgconf:amd64 (1.8.1-2build1) ...
Selecting previously unselected package pkg-config:amd64.
Preparing to unpack .../174-pkg-config_1.8.1-2build1_amd64.deb ...
Unpacking pkg-config:amd64 (1.8.1-2build1) ...
Selecting previously unselected package mono-devel.
Preparing to unpack .../175-mono-devel_6.8.0.105+dfsg-3.6ubuntu2_all.deb ...
Unpacking mono-devel (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libgraphite2-3:amd64 (1.3.14-2build1) ...
Setting up libpixman-1-0:amd64 (0.42.2-1build1) ...
Setting up lsb-base (11.6) ...
Setting up fontconfig (2.15.0-1.1ubuntu2) ...
Regenerating fonts cache... done.
Setting up fonts-noto-mono (20201225-2) ...
Setting up libdatrie1:amd64 (0.2.13-3build1) ...
Setting up libxcb-render0:amd64 (1.15-1ubuntu2) ...
Setting up libmonosgen-2.0-1 (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libsqlite3-0:amd64 (3.45.1-1ubuntu2.3) ...
Setting up fonts-freefont-otf (20211204+svn4273-2) ...
Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
Setting up libxcb-shm0:amd64 (1.15-1ubuntu2) ...
Setting up libcairo2:amd64 (1.18.0-3build1) ...
Setting up tzdata (2025b-0ubuntu0.24.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 79.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype

Current default time zone: 'Etc/UTC'
Local time is now:      Mon Jun 16 09:56:34 UTC 2025.
Universal Time is now:  Mon Jun 16 09:56:34 UTC 2025.
Run 'dpkg-reconfigure tzdata' if you wish to change it.

Setting up libfontenc1:amd64 (1:1.1.8-1build1) ...
Setting up libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.4) ...
No schema files found: doing nothing.
Setting up libpkgconf3:amd64 (1.8.1-2build1) ...
Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
Setting up libfribidi0:amd64 (1.0.13-3build1) ...
Setting up libexif12:amd64 (0.6.24-1build2) ...
Setting up pkgconf-bin (1.8.1-2build1) ...
Setting up fonts-texgyre (20180621-6) ...
Setting up fonts-croscore (20201225-2) ...
Setting up libgif7:amd64 (5.2.2-1ubuntu1) ...
Setting up fonts-liberation (1:2.1.5-3) ...
Setting up libharfbuzz0b:amd64 (8.3.0-2build2) ...
Setting up libthai-data (0.1.29-2build1) ...
Setting up fonts-noto-core (20201225-2) ...
Setting up libmonosgen-2.0-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up xfonts-utils (1:7.7+6build3) ...
Setting up libmono-corlib4.5-dll (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up pkgconf:amd64 (1.8.1-2build1) ...
Setting up libthai0:amd64 (0.1.29-2build1) ...
Setting up pkg-config:amd64 (1.8.1-2build1) ...
Setting up libmono-2.0-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-numerics4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libpango-1.0-0:amd64 (1.52.1+ds-1build1) ...
Setting up fonts-urw-base35 (20200910-8) ...
Setting up libpangoft2-1.0-0:amd64 (1.52.1+ds-1build1) ...
Setting up libpangocairo-1.0-0:amd64 (1.52.1+ds-1build1) ...
Setting up libgdiplus (6.1+dfsg-1build3) ...
Setting up libmono-system-core4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-xml4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-security4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-configuration4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-security4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up mono-4.0-gac (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up mono-gac (6.8.0.105+dfsg-3.6ubuntu2) ...
update-alternatives: using /usr/bin/gacutil to provide /usr/bin/cli-gacutil (global-assembly-cache-tool) in auto mode
Setting up mono-runtime-sgen (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up mono-runtime (6.8.0.105+dfsg-3.6ubuntu2) ...
update-alternatives: using /usr/bin/mono to provide /usr/bin/cli (cli) in auto mode
Setting up libmono-corlib4.5-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-compilerservices-symbolwriter4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-dynamic4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-xbuild-tasks4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-workflow-componentmodel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-cairo4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-net4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-build-framework4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-ldap-protocols4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-applicationservices4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-accessibility4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-cecil-private-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel-internals0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-configuration-install4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-numerics-vectors4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-componentmodel-composition4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-rabbitmq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-build-utilities-v4.0-4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up ca-certificates-mono (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-workflow-activities4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-xml-linq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-workflow-runtime4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-regularexpressions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-visualc10.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-simd4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-build-engine4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reflection-context4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-posix4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-peapi4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-data-tds4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-windows4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n-cjk4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-ldap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-interfaces2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-smdiagnostics0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel-activation4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-debugger-soft4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-net-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-deployment4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-io-compression4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-runtime-serialization4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-xaml4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-relaxng4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-messaging4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-tasklets4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-threading-tasks-dataflow4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-management4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-webbrowser4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-runtime-serialization-formatters-soap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n-mideast4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-codecontracts4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n-west4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-parallel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-mobile4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-json4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-management4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n-rare4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n-other4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-core2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-csharp4.0c-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-razor2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-drawing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-custommarshalers4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-sharpzip4.84-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-identitymodel4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data-services-client4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-csharp4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-build4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-transactions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-componentmodel-dataannotations4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-cscompmgd0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-messaging-rabbitmq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-json-microsoft4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-ldap4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-io-compression-filesystem4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-i18n4.0-all (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-build-tasks-v4.0-4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-linq2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-debugger2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-windowsbase4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-net-http-webrequest4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-windows-threading2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-runtime-durableinstancing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-runtime-remoting2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-enterpriseservices4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-platformservices2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-identitymodel-selectors4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up mono-mcs (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-experimental2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-providers2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-observable-aliases0.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data-datasetextensions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-runtime-caching4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-oracle4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-webmatrix-data4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-sqlite4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up mono-xbuild (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-net-http-formatting4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data-entity4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-windows-forms4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-db2-1.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data-linq4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-serviceprocess4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-windows-forms-datavisualization4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-messaging4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-drawing-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-reactive-windows-forms2.2-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-abstractions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-microsoft-web-infrastructure1.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-runtime4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-webpages-deployment2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-http-webhost4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-http4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-routing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-webpages2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-extensions-design4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-services4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-webpages-razor2.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel4.0a-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-xml-serialization4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel-routing4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel-discovery4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-http-selfhost4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-extensions4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-servicemodel-web4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-dynamicdata4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-web-mvc3.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-system-data-services4.0-cil (6.8.0.105+dfsg-3.6ubuntu2) ...
Setting up libmono-cil-dev (6.8.0.105+dfsg-3.6ubuntu2) ...
Processing triggers for libc-bin (2.39-0ubuntu8.4) ...
Processing triggers for man-db (2.12.0-4build2) ...
Processing triggers for ca-certificates (20240203) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
Updating Mono key store
Mono Certificate Store Sync - version 6.8.0.105
Populate Mono certificate store from a concatenated list of certificates.
Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.

Importing into legacy system store:
I already trust 0, your new list has 146
Certificate added: CN=ACCVRAIZ1, OU=PKIACCV, O=ACCV, C=ES
Certificate added: C=ES, O=FNMT-RCM, OU=AC RAIZ FNMT-RCM
Certificate added: C=ES, O=FNMT-RCM, OU=Ceres, OID.2.5.4.97=VATES-Q2826004J, CN=AC RAIZ FNMT-RCM SERVIDORES SEGUROS
Certificate added: SERIALNUMBER=G63287510, C=ES, O=ANF Autoridad de Certificacion, OU=ANF CA Raiz, CN=ANF Secure Server Root CA
Certificate added: C=IT, L=Milan, O=Actalis S.p.A./03358520967, CN=Actalis Authentication Root CA
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Commercial
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Networking
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium ECC
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 1
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 2
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 3
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 4
Certificate added: CN=Atos TrustedRoot 2011, O=Atos, C=DE
Certificate added: CN=Atos TrustedRoot Root CA ECC TLS 2021, O=Atos, C=DE
Certificate added: CN=Atos TrustedRoot Root CA RSA TLS 2021, O=Atos, C=DE
Certificate added: C=ES, CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
Certificate added: C=CN, O=BEIJING CERTIFICATE AUTHORITY, CN=BJCA Global Root CA1
Certificate added: C=CN, O=BEIJING CERTIFICATE AUTHORITY, CN=BJCA Global Root CA2
Certificate added: C=IE, O=Baltimore, OU=CyberTrust, CN=Baltimore CyberTrust Root
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 2 Root CA
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 3 Root CA
Certificate added: C=SK, L=Bratislava, O=Disig a.s., CN=CA Disig Root R2
Certificate added: C=CN, O=China Financial Certification Authority, CN=CFCA EV ROOT
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO ECC Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Certification Authority
Certificate added: C=US, O=Certainly, CN=Certainly Root E1
Certificate added: C=US, O=Certainly, CN=Certainly Root R1
Certificate added: C=FR, O=Dhimyotis, CN=Certigna
Certificate added: C=FR, O=Dhimyotis, OU=0002 48146308100036, CN=Certigna Root CA
Certificate added: C=PL, O=Asseco Data Systems S.A., OU=Certum Certification Authority, CN=Certum EC-384 CA
Certificate added: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority, CN=Certum Trusted Network CA
Certificate added: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority, CN=Certum Trusted Network CA 2
Certificate added: C=PL, O=Asseco Data Systems S.A., OU=Certum Certification Authority, CN=Certum Trusted Root CA
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust ECC Root-01
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust ECC Root-02
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust RSA Root-01
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust RSA Root-02
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=AAA Certificate Services
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST BR Root CA 1 2020
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST EV Root CA 1 2020
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 2009
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 EV 2009
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance EV Root CA
Certificate added: C=US, O="DigiCert, Inc.", CN=DigiCert TLS ECC P384 Root G5
Certificate added: C=US, O="DigiCert, Inc.", CN=DigiCert TLS RSA4096 Root G5
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root G4
Certificate added: O=Entrust.net, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), OU=(c) 1999 Entrust.net Limited, CN=Entrust.net Certification Authority (2048)
Certificate added: C=US, O="Entrust, Inc.", OU=www.entrust.net/CPS is incorporated by reference, OU="(c) 2006 Entrust, Inc.", CN=Entrust Root Certification Authority
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2012 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - EC1
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2009 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - G2
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2015 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - G4
Certificate added: C=CN, O="GUANG DONG CERTIFICATE AUTHORITY CO.,LTD.", CN=GDCA TrustAUTH R5 ROOT
Certificate added: C=AT, O=e-commerce monitoring GmbH, CN=GLOBALTRUST 2020
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R1
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R2
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R3
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R4
Certificate added: OU=GlobalSign ECC Root CA - R4, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign ECC Root CA - R5, O=GlobalSign, CN=GlobalSign
Certificate added: C=BE, O=GlobalSign nv-sa, OU=Root CA, CN=GlobalSign Root CA
Certificate added: OU=GlobalSign Root CA - R3, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign Root CA - R6, O=GlobalSign, CN=GlobalSign
Certificate added: C=BE, O=GlobalSign nv-sa, CN=GlobalSign Root E46
Certificate added: C=BE, O=GlobalSign nv-sa, CN=GlobalSign Root R46
Certificate added: C=US, O="The Go Daddy Group, Inc.", OU=Go Daddy Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="GoDaddy.com, Inc.", CN=Go Daddy Root Certificate Authority - G2
Certificate added: C=GR, O=Hellenic Academic and Research Institutions CA, CN=HARICA TLS ECC Root CA 2021
Certificate added: C=GR, O=Hellenic Academic and Research Institutions CA, CN=HARICA TLS RSA Root CA 2021
Certificate added: C=GR, L=Athens, O=Hellenic Academic and Research Institutions Cert. Authority, CN=Hellenic Academic and Research Institutions ECC RootCA 2015
Certificate added: C=GR, L=Athens, O=Hellenic Academic and Research Institutions Cert. Authority, CN=Hellenic Academic and Research Institutions RootCA 2015
Certificate added: C=TW, O="Chunghwa Telecom Co., Ltd.", CN=HiPKI Root CA - G1
Certificate added: C=HK, S=Hong Kong, L=Hong Kong, O=Hongkong Post, CN=Hongkong Post Root CA 3
Certificate added: C=US, O=Internet Security Research Group, CN=ISRG Root X1
Certificate added: C=US, O=Internet Security Research Group, CN=ISRG Root X2
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Commercial Root CA 1
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Public Sector Root CA 1
Certificate added: C=ES, O=IZENPE S.A., CN=Izenpe.com
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., CN=Microsec e-Szigno Root CA 2009, E=info@e-szigno.hu
Certificate added: C=US, O=Microsoft Corporation, CN=Microsoft ECC Root Certificate Authority 2017
Certificate added: C=US, O=Microsoft Corporation, CN=Microsoft RSA Root Certificate Authority 2017
Certificate added: C=KR, O=NAVER BUSINESS PLATFORM Corp., CN=NAVER Global Root Certification Authority
Certificate added: C=HU, L=Budapest, O=NetLock Kft., OU=Tanúsítványkiadók (Certification Services), CN=NetLock Arany (Class Gold) Főtanúsítvány
Certificate added: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GB CA
Certificate added: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GC CA
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 1 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3 G3
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com EV Root Certification Authority ECC
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com EV Root Certification Authority RSA R2
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com Root Certification Authority ECC
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com Root Certification Authority RSA
Certificate added: C=US, O=SSL Corporation, CN=SSL.com TLS ECC Root CA 2022
Certificate added: C=US, O=SSL Corporation, CN=SSL.com TLS RSA Root CA 2022
Certificate added: C=PL, O=Krajowa Izba Rozliczeniowa S.A., CN=SZAFIR ROOT CA2
Certificate added: C=GB, O=Sectigo Limited, CN=Sectigo Public Server Authentication Root E46
Certificate added: C=GB, O=Sectigo Limited, CN=Sectigo Public Server Authentication Root R46
Certificate added: C=JP, O="Japan Certification Services, Inc.", CN=SecureSign RootCA11
Certificate added: C=US, O=SecureTrust Corporation, CN=SecureTrust CA
Certificate added: C=US, O=SecureTrust Corporation, CN=Secure Global CA
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", CN=Security Communication ECC RootCA1
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", OU=Security Communication RootCA2
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", CN=Security Communication RootCA3
Certificate added: C=JP, O=SECOM Trust.net, OU=Security Communication RootCA1
Certificate added: C=US, O="Starfield Technologies, Inc.", OU=Starfield Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Root Certificate Authority - G2
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Services Root Certificate Authority - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Gold CA - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Silver CA - G2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 3
Certificate added: C=TR, L=Gebze - Kocaeli, O=Turkiye Bilimsel ve Teknolojik Arastirma Kurumu - TUBITAK, OU=Kamu Sertifikasyon Merkezi - Kamu SM, CN=TUBITAK Kamu SM SSL Kok Sertifikasi - Surum 1
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Global Root CA
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Root Certification Authority
Certificate added: O=TeliaSonera, CN=TeliaSonera Root CA v1
Certificate added: C=FI, O=Telia Finland Oyj, CN=Telia Root CA v2
Certificate added: C=CN, O="TrustAsia Technologies, Inc.", CN=TrustAsia Global Root CA G3
Certificate added: C=CN, O="TrustAsia Technologies, Inc.", CN=TrustAsia Global Root CA G4
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global Certification Authority
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global ECC P256 Certification Authority
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global ECC P384 Certification Authority
Certificate added: C=TN, O=Agence Nationale de Certification Electronique, CN=TunTrust Root CA
Certificate added: C=CN, O=UniTrust, CN=UCA Extended Validation Root
Certificate added: C=CN, O=UniTrust, CN=UCA Global G2 Root
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust ECC Certification Authority
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust RSA Certification Authority
Certificate added: C=US, OU=www.xrampsecurity.com, O=XRamp Security Services Inc, CN=XRamp Global Certification Authority
Certificate added: C=RO, O=certSIGN, OU=certSIGN ROOT CA
Certificate added: C=RO, O=CERTSIGN SA, OU=certSIGN ROOT CA G2
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., OID.2.5.4.97=VATHU-23584497, CN=e-Szigno Root CA 2017
Certificate added: C=TW, O="Chunghwa Telecom Co., Ltd.", OU=ePKI Root Certification Authority
Certificate added: C=US, OU=emSign PKI, O=eMudhra Inc, CN=emSign ECC Root CA - C3
Certificate added: C=IN, OU=emSign PKI, O=eMudhra Technologies Limited, CN=emSign ECC Root CA - G3
Certificate added: C=US, OU=emSign PKI, O=eMudhra Inc, CN=emSign Root CA - C1
Certificate added: C=IN, OU=emSign PKI, O=eMudhra Technologies Limited, CN=emSign Root CA - G1
Certificate added: C=CN, O="iTrusChina Co.,Ltd.", CN=vTrus ECC Root CA
Certificate added: C=CN, O="iTrusChina Co.,Ltd.", CN=vTrus Root CA
146 new root certificates were added to your trust store.
Import process completed.

Importing into BTLS system store:
I already trust 0, your new list has 146
Certificate added: CN=ACCVRAIZ1, OU=PKIACCV, O=ACCV, C=ES
Certificate added: C=ES, O=FNMT-RCM, OU=AC RAIZ FNMT-RCM
Certificate added: C=ES, O=FNMT-RCM, OU=Ceres, OID.2.5.4.97=VATES-Q2826004J, CN=AC RAIZ FNMT-RCM SERVIDORES SEGUROS
Certificate added: SERIALNUMBER=G63287510, C=ES, O=ANF Autoridad de Certificacion, OU=ANF CA Raiz, CN=ANF Secure Server Root CA
Certificate added: C=IT, L=Milan, O=Actalis S.p.A./03358520967, CN=Actalis Authentication Root CA
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Commercial
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Networking
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium ECC
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 1
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 2
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 3
Certificate added: C=US, O=Amazon, CN=Amazon Root CA 4
Certificate added: CN=Atos TrustedRoot 2011, O=Atos, C=DE
Certificate added: CN=Atos TrustedRoot Root CA ECC TLS 2021, O=Atos, C=DE
Certificate added: CN=Atos TrustedRoot Root CA RSA TLS 2021, O=Atos, C=DE
Certificate added: C=ES, CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
Certificate added: C=CN, O=BEIJING CERTIFICATE AUTHORITY, CN=BJCA Global Root CA1
Certificate added: C=CN, O=BEIJING CERTIFICATE AUTHORITY, CN=BJCA Global Root CA2
Certificate added: C=IE, O=Baltimore, OU=CyberTrust, CN=Baltimore CyberTrust Root
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 2 Root CA
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 3 Root CA
Certificate added: C=SK, L=Bratislava, O=Disig a.s., CN=CA Disig Root R2
Certificate added: C=CN, O=China Financial Certification Authority, CN=CFCA EV ROOT
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO ECC Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Certification Authority
Certificate added: C=US, O=Certainly, CN=Certainly Root E1
Certificate added: C=US, O=Certainly, CN=Certainly Root R1
Certificate added: C=FR, O=Dhimyotis, CN=Certigna
Certificate added: C=FR, O=Dhimyotis, OU=0002 48146308100036, CN=Certigna Root CA
Certificate added: C=PL, O=Asseco Data Systems S.A., OU=Certum Certification Authority, CN=Certum EC-384 CA
Certificate added: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority, CN=Certum Trusted Network CA
Certificate added: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority, CN=Certum Trusted Network CA 2
Certificate added: C=PL, O=Asseco Data Systems S.A., OU=Certum Certification Authority, CN=Certum Trusted Root CA
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust ECC Root-01
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust ECC Root-02
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust RSA Root-01
Certificate added: C=US, O=CommScope, CN=CommScope Public Trust RSA Root-02
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=AAA Certificate Services
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST BR Root CA 1 2020
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST EV Root CA 1 2020
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 2009
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 EV 2009
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance EV Root CA
Certificate added: C=US, O="DigiCert, Inc.", CN=DigiCert TLS ECC P384 Root G5
Certificate added: C=US, O="DigiCert, Inc.", CN=DigiCert TLS RSA4096 Root G5
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root G4
Certificate added: O=Entrust.net, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), OU=(c) 1999 Entrust.net Limited, CN=Entrust.net Certification Authority (2048)
Certificate added: C=US, O="Entrust, Inc.", OU=www.entrust.net/CPS is incorporated by reference, OU="(c) 2006 Entrust, Inc.", CN=Entrust Root Certification Authority
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2012 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - EC1
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2009 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - G2
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2015 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - G4
Certificate added: C=CN, O="GUANG DONG CERTIFICATE AUTHORITY CO.,LTD.", CN=GDCA TrustAUTH R5 ROOT
Certificate added: C=AT, O=e-commerce monitoring GmbH, CN=GLOBALTRUST 2020
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R1
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R2
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R3
Certificate added: C=US, O=Google Trust Services LLC, CN=GTS Root R4
Certificate added: OU=GlobalSign ECC Root CA - R4, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign ECC Root CA - R5, O=GlobalSign, CN=GlobalSign
Certificate added: C=BE, O=GlobalSign nv-sa, OU=Root CA, CN=GlobalSign Root CA
Certificate added: OU=GlobalSign Root CA - R3, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign Root CA - R6, O=GlobalSign, CN=GlobalSign
Certificate added: C=BE, O=GlobalSign nv-sa, CN=GlobalSign Root E46
Certificate added: C=BE, O=GlobalSign nv-sa, CN=GlobalSign Root R46
Certificate added: C=US, O="The Go Daddy Group, Inc.", OU=Go Daddy Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="GoDaddy.com, Inc.", CN=Go Daddy Root Certificate Authority - G2
Certificate added: C=GR, O=Hellenic Academic and Research Institutions CA, CN=HARICA TLS ECC Root CA 2021
Certificate added: C=GR, O=Hellenic Academic and Research Institutions CA, CN=HARICA TLS RSA Root CA 2021
Certificate added: C=GR, L=Athens, O=Hellenic Academic and Research Institutions Cert. Authority, CN=Hellenic Academic and Research Institutions ECC RootCA 2015
Certificate added: C=GR, L=Athens, O=Hellenic Academic and Research Institutions Cert. Authority, CN=Hellenic Academic and Research Institutions RootCA 2015
Certificate added: C=TW, O="Chunghwa Telecom Co., Ltd.", CN=HiPKI Root CA - G1
Certificate added: C=HK, S=Hong Kong, L=Hong Kong, O=Hongkong Post, CN=Hongkong Post Root CA 3
Certificate added: C=US, O=Internet Security Research Group, CN=ISRG Root X1
Certificate added: C=US, O=Internet Security Research Group, CN=ISRG Root X2
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Commercial Root CA 1
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Public Sector Root CA 1
Certificate added: C=ES, O=IZENPE S.A., CN=Izenpe.com
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., CN=Microsec e-Szigno Root CA 2009, E=info@e-szigno.hu
Certificate added: C=US, O=Microsoft Corporation, CN=Microsoft ECC Root Certificate Authority 2017
Certificate added: C=US, O=Microsoft Corporation, CN=Microsoft RSA Root Certificate Authority 2017
Certificate added: C=KR, O=NAVER BUSINESS PLATFORM Corp., CN=NAVER Global Root Certification Authority
Certificate added: C=HU, L=Budapest, O=NetLock Kft., OU=Tanúsítványkiadók (Certification Services), CN=NetLock Arany (Class Gold) Főtanúsítvány
Certificate added: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GB CA
Certificate added: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GC CA
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 1 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3 G3
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com EV Root Certification Authority ECC
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com EV Root Certification Authority RSA R2
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com Root Certification Authority ECC
Certificate added: C=US, S=Texas, L=Houston, O=SSL Corporation, CN=SSL.com Root Certification Authority RSA
Certificate added: C=US, O=SSL Corporation, CN=SSL.com TLS ECC Root CA 2022
Certificate added: C=US, O=SSL Corporation, CN=SSL.com TLS RSA Root CA 2022
Certificate added: C=PL, O=Krajowa Izba Rozliczeniowa S.A., CN=SZAFIR ROOT CA2
Certificate added: C=GB, O=Sectigo Limited, CN=Sectigo Public Server Authentication Root E46
Certificate added: C=GB, O=Sectigo Limited, CN=Sectigo Public Server Authentication Root R46
Certificate added: C=JP, O="Japan Certification Services, Inc.", CN=SecureSign RootCA11
Certificate added: C=US, O=SecureTrust Corporation, CN=SecureTrust CA
Certificate added: C=US, O=SecureTrust Corporation, CN=Secure Global CA
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", CN=Security Communication ECC RootCA1
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", OU=Security Communication RootCA2
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", CN=Security Communication RootCA3
Certificate added: C=JP, O=SECOM Trust.net, OU=Security Communication RootCA1
Certificate added: C=US, O="Starfield Technologies, Inc.", OU=Starfield Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Root Certificate Authority - G2
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Services Root Certificate Authority - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Gold CA - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Silver CA - G2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 3
Certificate added: C=TR, L=Gebze - Kocaeli, O=Turkiye Bilimsel ve Teknolojik Arastirma Kurumu - TUBITAK, OU=Kamu Sertifikasyon Merkezi - Kamu SM, CN=TUBITAK Kamu SM SSL Kok Sertifikasi - Surum 1
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Global Root CA
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Root Certification Authority
Certificate added: O=TeliaSonera, CN=TeliaSonera Root CA v1
Certificate added: C=FI, O=Telia Finland Oyj, CN=Telia Root CA v2
Certificate added: C=CN, O="TrustAsia Technologies, Inc.", CN=TrustAsia Global Root CA G3
Certificate added: C=CN, O="TrustAsia Technologies, Inc.", CN=TrustAsia Global Root CA G4
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global Certification Authority
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global ECC P256 Certification Authority
Certificate added: C=US, S=Illinois, L=Chicago, O="Trustwave Holdings, Inc.", CN=Trustwave Global ECC P384 Certification Authority
Certificate added: C=TN, O=Agence Nationale de Certification Electronique, CN=TunTrust Root CA
Certificate added: C=CN, O=UniTrust, CN=UCA Extended Validation Root
Certificate added: C=CN, O=UniTrust, CN=UCA Global G2 Root
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust ECC Certification Authority
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust RSA Certification Authority
Certificate added: C=US, OU=www.xrampsecurity.com, O=XRamp Security Services Inc, CN=XRamp Global Certification Authority
Certificate added: C=RO, O=certSIGN, OU=certSIGN ROOT CA
Certificate added: C=RO, O=CERTSIGN SA, OU=certSIGN ROOT CA G2
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., OID.2.5.4.97=VATHU-23584497, CN=e-Szigno Root CA 2017
Certificate added: C=TW, O="Chunghwa Telecom Co., Ltd.", OU=ePKI Root Certification Authority
Certificate added: C=US, OU=emSign PKI, O=eMudhra Inc, CN=emSign ECC Root CA - C3
Certificate added: C=IN, OU=emSign PKI, O=eMudhra Technologies Limited, CN=emSign ECC Root CA - G3
Certificate added: C=US, OU=emSign PKI, O=eMudhra Inc, CN=emSign Root CA - C1
Certificate added: C=IN, OU=emSign PKI, O=eMudhra Technologies Limited, CN=emSign Root CA - G1
Certificate added: C=CN, O="iTrusChina Co.,Ltd.", CN=vTrus ECC Root CA
Certificate added: C=CN, O="iTrusChina Co.,Ltd.", CN=vTrus Root CA
146 new root certificates were added to your trust store.
Import process completed.
Done
done.
Processing triggers for ntpsec (1.2.2+dfsg1-4build2) ...
Setting up mono-devel (6.8.0.105+dfsg-3.6ubuntu2) ...
update-alternatives: using /usr/bin/mono-csc to provide /usr/bin/cli-csc (c-sharp-compiler) in auto mode
update-alternatives: using /usr/bin/resgen to provide /usr/bin/cli-resgen (resource-file-generator) in auto mode
update-alternatives: using /usr/bin/al to provide /usr/bin/cli-al (assembly-linker) in auto mode
update-alternatives: using /usr/bin/sn to provide /usr/bin/cli-sn (strong-name-tool) in auto mode
Processing triggers for ca-certificates-java (20240118) ...
done.

>>>> xbuild tool is deprecated and will be removed in future updates, use msbuild instead <<<<

XBuild Engine Version 14.0
Mono, Version 6.8.0.105
Copyright (C) 2005-2013 Various Mono authors

Build started 06/16/2025 09:56:50.
__________________________________________________
Project "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/DelphixConnectorService.csproj" (default target(s)):
        Target PrepareForBuild:
                Configuration: Debug Platform: AnyCPU
                Created directory "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/"
                Created directory "obj/Debug/"
        Target GenerateSatelliteAssemblies:
        No input files were specified for target GenerateSatelliteAssemblies, skipping.
        Target CoreCompile:
                Tool /usr/lib/mono/4.5/mcs.exe execution started with arguments: /noconfig /debug:full /debug:portable /out:obj/Debug/DelphixConnectorService.exe DelphixConnectorServiceInstaller.cs DelphixConnectorServiceInstaller.Designer.cs DelphixConnectorService.cs DelphixConnectorService.Designer.cs DelphixConnectorServiceLauncher.cs Properties/AssemblyInfo.cs DelphixConnectorServiceHelper.cs obj/Debug/.NETFramework,Version=v4.0.AssemblyAttribute.cs /target:winexe /define:"DEBUG;TRACE" /nostdlib /platform:AnyCPU /reference:/usr/lib/mono/4.0-api/System.dll /reference:/usr/lib/mono/4.0-api/System.Configuration.Install.dll /reference:/usr/lib/mono/4.0-api/System.Management.dll /reference:/usr/lib/mono/4.0-api/System.ServiceProcess.dll /reference:/usr/lib/mono/4.0-api/System.Windows.Forms.dll /reference:/usr/lib/mono/4.0-api/System.Core.dll /reference:/usr/lib/mono/4.0-api//mscorlib.dll
        Target DeployOutputFiles:
                Copying file from '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/obj/Debug/DelphixConnectorService.exe.mdb' to '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/DelphixConnectorService.exe.mdb'
                Copying file from '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/obj/Debug/DelphixConnectorService.exe' to '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/DelphixConnectorService.exe'
Done building project "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/DelphixConnectorService.csproj".

Build succeeded.
         0 Warning(s)
         0 Error(s)

Time Elapsed 00:00:00.7442200

>>>> xbuild tool is deprecated and will be removed in future updates, use msbuild instead <<<<

XBuild Engine Version 14.0
Mono, Version 6.8.0.105
Copyright (C) 2005-2013 Various Mono authors

Build started 06/16/2025 09:56:51.
__________________________________________________
Project "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/DelphixConnectorService.csproj" (default target(s)):
        Target PrepareForBuild:
                Configuration: Debug Platform: AnyCPU
                Created directory "obj/Debug/"
        Target GenerateSatelliteAssemblies:
        No input files were specified for target GenerateSatelliteAssemblies, skipping.
        Target CoreCompile:
                Tool /usr/lib/mono/4.5/mcs.exe execution started with arguments: /noconfig /debug:full /debug:portable /out:obj/Debug/DelphixConnectorService.exe DelphixConnectorServiceInstaller.cs DelphixConnectorServiceInstaller.Designer.cs DelphixConnectorService.cs DelphixConnectorService.Designer.cs DelphixConnectorServiceLauncher.cs Properties/AssemblyInfo.cs DelphixConnectorServiceHelper.cs /target:winexe /define:"DEBUG;TRACE" /nostdlib /platform:AnyCPU /reference:/usr/lib/mono/2.0-api/System.dll /reference:/usr/lib/mono/2.0-api/System.Configuration.Install.dll /reference:/usr/lib/mono/2.0-api/System.Management.dll /reference:/usr/lib/mono/2.0-api/System.ServiceProcess.dll /reference:/usr/lib/mono/2.0-api/System.Windows.Forms.dll /reference:/usr/lib/mono/2.0-api/System.Core.dll /reference:/usr/lib/mono/2.0-api//mscorlib.dll
        Target DeployOutputFiles:
                Copying file from '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/obj/Debug/DelphixConnectorService.exe.mdb' to '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/DelphixConnectorService.exe.mdb'
                Copying file from '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/obj/Debug/DelphixConnectorService.exe' to '/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/DelphixConnectorService.exe'
Done building project "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/DelphixConnector/LinuxArtifacts/service/DelphixConnectorService.csproj".

Build succeeded.
         0 Warning(s)
         0 Error(s)

Time Elapsed 00:00:00.6010910

> Task :host:windows:buildDlpxRunAs
Reading package lists...
Building dependency tree...NG [2m 10s]
Reading state information...
binutils-common is already the newest version (2.42-4ubuntu2.5).
gcc-14-base is already the newest version (14.2.0-4ubuntu2~24.04).
libc6 is already the newest version (2.39-0ubuntu8.4).
libgcc-s1 is already the newest version (14.2.0-4ubuntu2~24.04).
libgmp10 is already the newest version (2:6.3.0+dfsg-2ubuntu6.1).
libisl23 is already the newest version (0.26-3build1.1).
libisl23 set to manually installed.
libmpc3 is already the newest version (1.3.1-1build1.1).
libmpc3 set to manually installed.
libmpfr6 is already the newest version (4.2.1-1build1.1).
libmpfr6 set to manually installed.
libstdc++6 is already the newest version (14.2.0-4ubuntu2~24.04).
libzstd1 is already the newest version (1.5.5+dfsg2-2build1.1).
zlib1g is already the newest version (1:1.3.dfsg-3.1ubuntu2.1).
Suggested packages:
  gcc-13-locales wine wine64
The following NEW packages will be installed:
  binutils-mingw-w64-i686 binutils-mingw-w64-x86-64 g++-mingw-w64
  g++-mingw-w64-i686 g++-mingw-w64-i686-posix g++-mingw-w64-i686-win32
  g++-mingw-w64-x86-64 g++-mingw-w64-x86-64-posix g++-mingw-w64-x86-64-win32
  gcc-mingw-w64 gcc-mingw-w64-base gcc-mingw-w64-i686 gcc-mingw-w64-i686-posix
  gcc-mingw-w64-i686-posix-runtime gcc-mingw-w64-i686-win32
  gcc-mingw-w64-i686-win32-runtime gcc-mingw-w64-x86-64
  gcc-mingw-w64-x86-64-posix gcc-mingw-w64-x86-64-posix-runtime
  gcc-mingw-w64-x86-64-win32 gcc-mingw-w64-x86-64-win32-runtime mingw-w64
  mingw-w64-common mingw-w64-i686-dev mingw-w64-x86-64-dev
0 upgraded, 25 newly installed, 0 to remove and 31 not upgraded.
Need to get 277 MB of archives.
After this operation, 1293 MB of additional disk space will be used.
Get:1 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 binutils-mingw-w64-i686 amd64 2.41.90.20240122-1ubuntu1+11.4 [2975 kB]
Get:2 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mingw-w64-common all 11.0.1-3build1 [5580 kB]
Get:3 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mingw-w64-i686-dev all 11.0.1-3build1 [3153 kB]
Get:4 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-base amd64 13.2.0-6ubuntu1+26.1 [188 kB]
Get:5 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-i686-posix-runtime amd64 13.2.0-6ubuntu1+26.1 [13.1 MB]
Get:6 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-i686-posix amd64 13.2.0-6ubuntu1+26.1 [35.2 MB]
Get:7 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-i686-posix amd64 13.2.0-6ubuntu1+26.1 [14.5 MB]
Get:8 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-i686-win32-runtime amd64 13.2.0-6ubuntu1+26.1 [13.3 MB]
Get:9 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-i686-win32 amd64 13.2.0-6ubuntu1+26.1 [35.2 MB]
Get:10 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-i686-win32 amd64 13.2.0-6ubuntu1+26.1 [14.5 MB]
Get:11 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 binutils-mingw-w64-x86-64 amd64 2.41.90.20240122-1ubuntu1+11.4 [6053 kB]
Get:12 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mingw-w64-x86-64-dev all 11.0.1-3build1 [3786 kB]
Get:13 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-x86-64-posix-runtime amd64 13.2.0-6ubuntu1+26.1 [14.0 MB]
Get:14 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-x86-64-posix amd64 13.2.0-6ubuntu1+26.1 [35.4 MB]
Get:15 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-x86-64-posix amd64 13.2.0-6ubuntu1+26.1 [14.7 MB]
Get:16 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-x86-64-win32-runtime amd64 13.2.0-6ubuntu1+26.1 [14.2 MB]
Get:17 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-x86-64-win32 amd64 13.2.0-6ubuntu1+26.1 [35.4 MB]
Get:18 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-x86-64-win32 amd64 13.2.0-6ubuntu1+26.1 [14.7 MB]
Get:19 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-i686 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:20 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64-x86-64 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:21 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 g++-mingw-w64 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:22 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-i686 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:23 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64-x86-64 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:24 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 gcc-mingw-w64 all 13.2.0-6ubuntu1+26.1 [187 kB]
Get:25 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 mingw-w64 all 11.0.1-3build1 [11.0 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 277 MB in 4s (77.2 MB/s)
Selecting previously unselected package binutils-mingw-w64-i686.
(Reading database ... 150689 files and directories currently installed.)
Preparing to unpack .../00-binutils-mingw-w64-i686_2.41.90.20240122-1ubuntu1+11.4_amd64.deb ...
Unpacking binutils-mingw-w64-i686 (2.41.90.20240122-1ubuntu1+11.4) ...
Selecting previously unselected package mingw-w64-common.
Preparing to unpack .../01-mingw-w64-common_11.0.1-3build1_all.deb ...
Unpacking mingw-w64-common (11.0.1-3build1) ...
Selecting previously unselected package mingw-w64-i686-dev.
Preparing to unpack .../02-mingw-w64-i686-dev_11.0.1-3build1_all.deb ...
Unpacking mingw-w64-i686-dev (11.0.1-3build1) ...
Selecting previously unselected package gcc-mingw-w64-base:amd64.
Preparing to unpack .../03-gcc-mingw-w64-base_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-base:amd64 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-i686-posix-runtime.
Preparing to unpack .../04-gcc-mingw-w64-i686-posix-runtime_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-i686-posix-runtime (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-i686-posix.
Preparing to unpack .../05-gcc-mingw-w64-i686-posix_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-i686-posix (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-i686-posix.
Preparing to unpack .../06-g++-mingw-w64-i686-posix_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking g++-mingw-w64-i686-posix (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-i686-win32-runtime.
Preparing to unpack .../07-gcc-mingw-w64-i686-win32-runtime_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-i686-win32-runtime (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-i686-win32.
Preparing to unpack .../08-gcc-mingw-w64-i686-win32_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-i686-win32 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-i686-win32.
Preparing to unpack .../09-g++-mingw-w64-i686-win32_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking g++-mingw-w64-i686-win32 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package binutils-mingw-w64-x86-64.
Preparing to unpack .../10-binutils-mingw-w64-x86-64_2.41.90.20240122-1ubuntu1+11.4_amd64.deb ...
Unpacking binutils-mingw-w64-x86-64 (2.41.90.20240122-1ubuntu1+11.4) ...
Selecting previously unselected package mingw-w64-x86-64-dev.
Preparing to unpack .../11-mingw-w64-x86-64-dev_11.0.1-3build1_all.deb ...
Unpacking mingw-w64-x86-64-dev (11.0.1-3build1) ...
Selecting previously unselected package gcc-mingw-w64-x86-64-posix-runtime.
Preparing to unpack .../12-gcc-mingw-w64-x86-64-posix-runtime_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-x86-64-posix-runtime (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-x86-64-posix.
Preparing to unpack .../13-gcc-mingw-w64-x86-64-posix_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-x86-64-posix (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-x86-64-posix.
Preparing to unpack .../14-g++-mingw-w64-x86-64-posix_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking g++-mingw-w64-x86-64-posix (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-x86-64-win32-runtime.
Preparing to unpack .../15-gcc-mingw-w64-x86-64-win32-runtime_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-x86-64-win32-runtime (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-x86-64-win32.
Preparing to unpack .../16-gcc-mingw-w64-x86-64-win32_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking gcc-mingw-w64-x86-64-win32 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-x86-64-win32.
Preparing to unpack .../17-g++-mingw-w64-x86-64-win32_13.2.0-6ubuntu1+26.1_amd64.deb ...
Unpacking g++-mingw-w64-x86-64-win32 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-i686.
Preparing to unpack .../18-g++-mingw-w64-i686_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking g++-mingw-w64-i686 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64-x86-64.
Preparing to unpack .../19-g++-mingw-w64-x86-64_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking g++-mingw-w64-x86-64 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package g++-mingw-w64.
Preparing to unpack .../20-g++-mingw-w64_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking g++-mingw-w64 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-i686.
Preparing to unpack .../21-gcc-mingw-w64-i686_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking gcc-mingw-w64-i686 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64-x86-64.
Preparing to unpack .../22-gcc-mingw-w64-x86-64_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking gcc-mingw-w64-x86-64 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package gcc-mingw-w64.
Preparing to unpack .../23-gcc-mingw-w64_13.2.0-6ubuntu1+26.1_all.deb ...
Unpacking gcc-mingw-w64 (13.2.0-6ubuntu1+26.1) ...
Selecting previously unselected package mingw-w64.
Preparing to unpack .../24-mingw-w64_11.0.1-3build1_all.deb ...
Unpacking mingw-w64 (11.0.1-3build1) ...
Setting up binutils-mingw-w64-x86-64 (2.41.90.20240122-1ubuntu1+11.4) ...
Setting up gcc-mingw-w64-base:amd64 (13.2.0-6ubuntu1+26.1) ...
Setting up gcc-mingw-w64-i686-posix-runtime (13.2.0-6ubuntu1+26.1) ...
Setting up binutils-mingw-w64-i686 (2.41.90.20240122-1ubuntu1+11.4) ...
Setting up gcc-mingw-w64-x86-64-win32-runtime (13.2.0-6ubuntu1+26.1) ...
Setting up gcc-mingw-w64-i686-win32-runtime (13.2.0-6ubuntu1+26.1) ...
Setting up mingw-w64-common (11.0.1-3build1) ...
Setting up mingw-w64-x86-64-dev (11.0.1-3build1) ...
Setting up gcc-mingw-w64-x86-64-posix-runtime (13.2.0-6ubuntu1+26.1) ...
Setting up gcc-mingw-w64-x86-64-posix (13.2.0-6ubuntu1+26.1) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-gcc-posix to provide /usr/bin/x86_64-w64-mingw32-gcc (x86_64-w64-mingw32-gcc) in auto mode
Setting up gcc-mingw-w64-x86-64-win32 (13.2.0-6ubuntu1+26.1) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-gcc-win32 to provide /usr/bin/x86_64-w64-mingw32-gcc (x86_64-w64-mingw32-gcc) in auto mode
Setting up gcc-mingw-w64-x86-64 (13.2.0-6ubuntu1+26.1) ...
Setting up mingw-w64-i686-dev (11.0.1-3build1) ...
Setting up gcc-mingw-w64-i686-win32 (13.2.0-6ubuntu1+26.1) ...
update-alternatives: using /usr/bin/i686-w64-mingw32-gcc-win32 to provide /usr/bin/i686-w64-mingw32-gcc (i686-w64-mingw32-gcc) in auto mode
Setting up g++-mingw-w64-i686-win32 (13.2.0-6ubuntu1+26.1) ...
update-alternatives: using /usr/bin/i686-w64-mingw32-g++-win32 to provide /usr/bin/i686-w64-mingw32-g++ (i686-w64-mingw32-g++) in auto mode
Setting up g++-mingw-w64-x86-64-win32 (13.2.0-6ubuntu1+26.1) ...
update-alternatives: using /usr/bin/x86_64-w64-mingw32-g++-win32 to provide /usr/bin/x86_64-w64-mingw32-g++ (x86_64-w64-mingw32-g++) in auto mode
Setting up gcc-mingw-w64-i686-posix (13.2.0-6ubuntu1+26.1) ...
Setting up g++-mingw-w64-x86-64-posix (13.2.0-6ubuntu1+26.1) ...
Setting up gcc-mingw-w64-i686 (13.2.0-6ubuntu1+26.1) ...
Setting up g++-mingw-w64-x86-64 (13.2.0-6ubuntu1+26.1) ...
Setting up gcc-mingw-w64 (13.2.0-6ubuntu1+26.1) ...
Setting up g++-mingw-w64-i686-posix (13.2.0-6ubuntu1+26.1) ...
Setting up g++-mingw-w64-i686 (13.2.0-6ubuntu1+26.1) ...
Setting up g++-mingw-w64 (13.2.0-6ubuntu1+26.1) ...
Setting up mingw-w64 (11.0.1-3build1) ...
Processing triggers for man-db (2.12.0-4build2) ...
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘void vhwprintf(HANDLE, wchar_t*, ...)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:144:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  144 |             vhwprintf(STDERR, L"DLPX_ERR_MALLOC %d\n", newsz);
      |                               ^~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘DWORD launchChildProcess(PWCHAR, PWCHAR, PWCHAR, PWCHAR, PWCHAR, HANDLE, HANDLE, HANDLE, PHANDLE, PDWORD, BOOL, BOOL)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:229:24: warning: ISO C++ forbids converting a string constant to ‘LPWSTR’ {aka ‘wchar_t*’} [-Wwrite-strings]
  229 |         si.lpDesktop = L"winsta0\\default";
      |                        ^~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:231:24: warning: ISO C++ forbids converting a string constant to ‘LPWSTR’ {aka ‘wchar_t*’} [-Wwrite-strings]
  231 |         si.lpDesktop = L"";
      |                        ^~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:270:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  270 |             vhwprintf(STDERR, L"LOGONUSER FAILED %d\n", GetLastError());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:284:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  284 |             vhwprintf(STDERR, L"DUPLICATE TOKEN FAILED %d\n", GetLastError());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘void disinheritHandle(HANDLE, void**)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:371:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  371 |         vhwprintf(STDERR, L"DLPX_ERR_DUPLICATEHANDLE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘void disinheritStdHandle(DWORD)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:388:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  388 |         vhwprintf(STDERR, L"DLPX_ERR_GETSTDHANDLE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:401:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  401 |         vhwprintf(STDERR, L"DLPX_ERR_DUPLICATEHANDLE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:406:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  406 |         vhwprintf(STDERR, L"DLPX_ERR_SETSTDHANDLE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘DWORD fetchEnvVar(PWCHAR, PWCHAR, DWORD, BOOLEAN)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:470:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  470 |         vhwprintf(STDERR, L"DLPX_ERR_FETCHENVVAR(%s) %d\n", envVar, GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:475:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  475 |         vhwprintf(STDERR, L"DLPX_ERR_FETCHENVVAR_BUFFEROVERFLOW(%S)", envVar);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp: In function ‘int wmain(int, _TCHAR**)’:
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:673:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  673 |         vhwprintf(STDERR, L"DLPX_ERR_GET_VERSION: %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:680:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  680 |         vhwprintf(STDERR, L"%s <command> [args]\n"
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~
  681 |                  L"environment:\n"
      |                  ~~~~~~~~~~~~~~~~~
  682 |                  L"delphix_username\n"
      |                  ~~~~~~~~~~~~~~~~~~~~~
  683 |                  L"delphix_password\n"
      |                  ~~~~~~~~~~~~~~~~~~~~~
  684 |                  L"[delphix_dir_path]\n", argv[0]);
      |                  ~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:690:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  690 |         vhwprintf(STDERR, L"DLPX_ERR_BUILDCMDSTRING\n");
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:696:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  696 |         vhwprintf(STDERR, L"DLPX_ERR_REGISTER_CTRL_HANDLER %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:38:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   38 | #define DELPHIX_USERNAME   L"delphix_username"
      |                            ^~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:700:27: note: in expansion of macro ‘DELPHIX_USERNAME’
  700 |     if (err = fetchEnvVar(DELPHIX_USERNAME, userAndDom, sizeof(userAndDom), false)) {
      |                           ^~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:701:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  701 |         vhwprintf(STDERR, L"DLPX_ERR_GET_ENV_DELPHIX_USERNAME %d\n", __LINE__);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:39:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   39 | #define DELPHIX_PASSWORD   L"delphix_password"
      |                            ^~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:705:27: note: in expansion of macro ‘DELPHIX_PASSWORD’
  705 |     if (err = fetchEnvVar(DELPHIX_PASSWORD, password, sizeof(password), false)) {
      |                           ^~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:706:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  706 |         vhwprintf(STDERR, L"DLPX_ERR_GET_ENV_DELPHIX_PASSWORD %d\n", __LINE__);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:40:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   40 | #define DELPHIX_QUOTE_CHAR L"delphix_quote_char"
      |                            ^~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:710:22: note: in expansion of macro ‘DELPHIX_QUOTE_CHAR’
  710 |     if (!fetchEnvVar(DELPHIX_QUOTE_CHAR, quoteval, sizeof(quoteval), false)) {
      |                      ^~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:41:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   41 | #define DELPHIX_DIR_PATH   L"delphix_dir_path"
      |                            ^~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:718:22: note: in expansion of macro ‘DELPHIX_DIR_PATH’
  718 |     if (!fetchEnvVar(DELPHIX_DIR_PATH, dirpath, sizeof(dirpath), false)) {
      |                      ^~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:42:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   42 | #define DELPHIX_BOOTSTRAP  L"delphix_bootstrap"
      |                            ^~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:722:22: note: in expansion of macro ‘DELPHIX_BOOTSTRAP’
  722 |     if (!fetchEnvVar(DELPHIX_BOOTSTRAP, bootstrap, sizeof(bootstrap), false)) {
      |                      ^~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:43:28: warning: ISO C++ forbids converting a string constant to ‘PWCHAR’ {aka ‘wchar_t*’} [-Wwrite-strings]
   43 | #define DELPHIX_SKIPAUTH   L"delphix_skipauth"
      |                            ^~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:726:22: note: in expansion of macro ‘DELPHIX_SKIPAUTH’
  726 |     if (!fetchEnvVar(DELPHIX_SKIPAUTH, skipAuth, sizeof(skipAuth), false)) {
      |                      ^~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:753:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  753 |         vhwprintf(STDERR, L"DLPX_ERR_CREATEPIPE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:759:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  759 |         vhwprintf(STDERR, L"DLPX_ERR_CREATEPIPE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:765:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  765 |         vhwprintf(STDERR, L"DLPX_ERR_CREATEPIPE %d\n", GetLastError());
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:793:27: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  793 |         vhwprintf(STDERR, L"DLPX_ERR_LAUNCHCHILDPROCESS %d\n", err);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:838:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  838 |             vhwprintf(STDERR, L"DLPX_ERR_WAIT_FAILED %d\n", GetLastError());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:849:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  849 |             vhwprintf(STDERR, L"DLPX_ERR_WAIT_MULTI %d\n", GetLastError());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:856:35: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  856 |                 vhwprintf(STDERR, L"DLPX_ERR_GETEXITCODE %d\n", GetLastError());
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
DelphixConnector/LinuxArtifacts/dlpxrunas/dlpxrunas.cpp:868:31: warning: ISO C++ forbids converting a string constant to ‘wchar_t*’ [-Wwrite-strings]
  868 |             vhwprintf(STDERR, L"DLPX_ERR_GETEXITCODE %d\n", GetLastError());
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

> Task :host:windows:downloadJre
Download http://artifactory.delphix.com/artifactory/delphix-java-packages/windows/jre1.8/OpenJDK8U-jre_x64_windows_hotspot_8u442b06.zip

> Task :host:windows:buildWindowsConnectorInstaller
Reading package lists...
Building dependency tree...
Reading state information...
gcc-14-base is already the newest version (14.2.0-4ubuntu2~24.04).
libc6 is already the newest version (2.39-0ubuntu8.4).
libgcc-s1 is already the newest version (14.2.0-4ubuntu2~24.04).
libstdc++6 is already the newest version (14.2.0-4ubuntu2~24.04).
zlib1g is already the newest version (1:1.3.dfsg-3.1ubuntu2.1).
Suggested packages:
  nsis-doc nsis-pluginapi wine
The following NEW packages will be installed:
  nsis nsis-common
0 upgraded, 2 newly installed, 0 to remove and 31 not upgraded.
Need to get 1288 kB of archives.
After this operation, 7318 kB of additional disk space will be used.
Get:1 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 nsis-common all 3.09-4ubuntu1 [968 kB]
Get:2 http://linux-package-mirror-v2.delphix.com/develop/ea24e9c4/ubuntu noble/universe amd64 nsis amd64 3.09-4ubuntu1 [320 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 1288 kB in 0s (13.4 MB/s)
Selecting previously unselected package nsis-common.
(Reading database ... 163445 files and directories currently installed.)
Preparing to unpack .../nsis-common_3.09-4ubuntu1_all.deb ...
Unpacking nsis-common (3.09-4ubuntu1) ...
Selecting previously unselected package nsis.
Preparing to unpack .../nsis_3.09-4ubuntu1_amd64.deb ...
Unpacking nsis (3.09-4ubuntu1) ...
Setting up nsis-common (3.09-4ubuntu1) ...
Setting up nsis (3.09-4ubuntu1) ...
Processing triggers for man-db (2.12.0-4build2) ...
Command line defined: "VERSION=1.41.0.0"
Command line defined: "BUILDPATH=/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector"
Processing config: /etc/nsisconf.nsh
Processing script file: "DelphixConnector/LinuxArtifacts/DelphixConnectorInstaller.nsi" (UTF8)

Processed 1 file, 1 command line command, writing output (x86-unicode):
warning 9100: Generating version information for language "1033-English" without standard key "FileVersion"
warning 9100: Generating version information for language "1033-English" without standard key "FileDescription"
warning 9100: Generating version information for language "1033-English" without standard key "LegalCopyright"

Output: "/export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo/appliance/host/windows/build/DelphixConnector/DelphixConnectorInstaller.exe"
Install: 8 pages (512 bytes), 2 sections (8240 bytes), 2556 instructions (71568 bytes), 501 strings (186512 bytes), 1 language table (322 bytes).
Uninstall: 1 page (128 bytes), 1 section (4120 bytes), 879 instructions (24612 bytes), 182 strings (8656 bytes), 1 language table (230 bytes).
Datablock optimizer saved 17882 bytes (~0.0%).

Using zlib compression.

EXE header size:              100864 / 100352 bytes
Install code:                  34939 / 263546 bytes
Install data:               53983244 / 57166935 bytes
Uninstall code+data:           24157 / 24790 bytes
CRC (0x11A023CF):                  4 / 4 bytes

Total size:                 54143208 / 57555627 bytes (94.0%)

3 warnings:
  9100: Generating version information for language "1033-English" without standard key "FileVersion"
  9100: Generating version information for language "1033-English" without standard key "FileDescription"
  9100: Generating version information for language "1033-English" without standard key "LegalCopyright"

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 56s
40 actionable tasks: 9 executed, 31 up-to-date
Running: sudo mv ./build/distributions/windows-connector_2025.06.16.09_all.deb /export/home/delphix/linux-pkg/packages/windows-connector/tmp/artifacts/
PACKAGE windows-connector: STAGE build COMPLETED in 458 seconds

Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: STAGE store_build_info STARTED
Running: store_build_info
Running: store_git_info
Running: pushd /export/home/delphix/linux-pkg/packages/windows-connector/tmp/repo
~/linux-pkg/packages/windows-connector/tmp/repo ~/linux-pkg/packages/windows-connector/tmp
Running: popd
~/linux-pkg/packages/windows-connector/tmp
Running: cp /export/home/delphix/linux-pkg/PACKAGE_MIRROR_URL_MAIN /export/home/delphix/linux-pkg/packages/windows-connector/tmp/artifacts/
Running: cp /export/home/delphix/linux-pkg/PACKAGE_MIRROR_URL_SECONDARY /export/home/delphix/linux-pkg/packages/windows-connector/tmp/artifacts/
PACKAGE windows-connector: STAGE store_build_info COMPLETED in 0 seconds

Running: cd /export/home/delphix/linux-pkg/packages/windows-connector/tmp

PACKAGE windows-connector: STAGE post_build_checks STARTED
Running: post_build_checks
PACKAGE windows-connector: STAGE post_build_checks COMPLETED in 0 seconds

Success: Package windows-connector has been built successfully.
Build products are in /export/home/delphix/linux-pkg/packages/windows-connector/tmp/artifacts

delphix@ip-10-110-210-165:~/linux-pkg$ dpkg -c packages/windows-connector/tmp/artifacts/windows-connector_2025.06.12.15_all.deb
dpkg-deb: error: failed to read archive 'packages/windows-connector/tmp/artifacts/windows-connector_2025.06.12.15_all.deb': No such file or directory
delphix@ip-10-110-210-165:~/linux-pkg$ dpkg -c packages/windows-connector/tmp/artifacts/windows-connector_2025.06.16.09_all.deb 
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/delphix/
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/delphix/host/
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/delphix/host/windows/
-rwxr-xr-x root/0     54143208 2025-06-16 09:58 ./opt/delphix/host/windows/DelphixConnectorInstaller.exe
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/delphix/host/windows/bin/
drwxr-xr-x root/0            0 2025-06-16 09:58 ./opt/delphix/host/windows/bin/bootstrap/
-rwxr-xr-x root/0        26112 2025-06-16 09:58 ./opt/delphix/host/windows/bin/bootstrap/dlpxrunas.exe
```

</details>

**What’s Next?**

The dlpx-app-gate will begin using the Debian package to install the Windows connector installer and dlpxrunas.exe on the engine.

Existing installer build logic will be refactored accordingly.

A JIRA ticket has been created to track this work. https://perforce.atlassian.net/browse/CP-12535