### PR TITLE
DLPX-94508 Combine-packages is failing with "Latest artifact not found for package windows-connector"

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -30,4 +30,3 @@ savedump
 sdb
 targetcli-fb
 virtualization
-windows-connector


### PR DESCRIPTION
Our current strategy to build the connector package did not work as expected. [PR Link](https://github.com/delphix/linux-pkg/pull/351)

We assumed that adding the entry in the main.py file wouldn’t impact the engine build process, since no dependency on the package has been defined in the app-gate yet. However, the issue is that the combine-packages task still attempts to resolve all listed packages, and since the connector package hasn’t been built yet, this leads to a failure.

We also attempted to build the package manually, but that failed with the following error:

 [Build log](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-packages/job/pre-push/4709/console)

```
20:13:34  ERROR: No item named /linux-pkg/develop/build-package/windows-connector/pre-push found
```

It appears that the pre-push job isn’t being generated for this new package as we expected. We initially thought that adding the entry in main.py would be sufficient to trigger it.

For now, we are reverting the change in main.py until we determine the correct way to generate the pre-push job for this package.