### PR TITLE
CP-12547 linux-pkg Changes 2: Build Connector using Linux Package Framework

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -30,3 +30,4 @@ savedump
 sdb
 targetcli-fb
 virtualization
+windows-connector


### PR DESCRIPTION
We had reverted the changes from this diff in [this PR](https://github.com/delphix/linux-pkg/pull/352/files) due to failures encountered by other users when running `git-ab-pre-push`.

The root cause is the combine-packages step failing with the following error:
"Latest artifact not found for package windows-connector"

Now that the Windows-connector package has been successfully built, this issue should no longer occur. Reapplying this change will also help unblock testing for the related app-gate change that depends on this new package.

**Testing**

I respawned one of the previously failing runs by updating the linux-pkg branch to point to my custom branch.

https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/combine-packages/job/pre-push/3987/consoleFull