### PR TITLE
DLPX-84445 Generate BTF for our custom zfs and spl kernel modules

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -597,6 +597,47 @@ function install_kernel_headers() {
 	done
 }
 
+#
+# Install kernel dbgsym packages for all target kernels.
+# The kernel packages are fetched from S3.
+#
+function install_kernel_dbgsyms() {
+	logmust determine_target_kernels
+	check_env KERNEL_VERSIONS DEPDIR
+
+	logmust list_linux_kernel_packages
+	# Note: linux packages returned in _RET_LIST
+
+	local pkg
+	for pkg in "${_RET_LIST[@]}"; do
+		logmust install_pkgs "$DEPDIR/$pkg/"linux-image-*dbgsym*.ddeb
+	done
+
+	#
+	# Verify that headers are installed for all kernel versions
+	# stored in KERNEL_VERSIONS
+	#
+	local kernel
+	for kernel in $KERNEL_VERSIONS; do
+		logmust dpkg-query -l "linux-image-$kernel-dbgsym*" >/dev/null
+	done
+}
+
+function install_kernel_headers_and_dbgsyms() {
+	logmust install_kernel_headers
+	logmust install_kernel_dbgsyms
+
+	#
+	# Additionally, we add these symlinks so that kernel module builds will
+	# be able to generate BTF information, as they look for the "vmlinux" file
+	# in the kernel header directory.
+	#
+	local kernel
+	for kernel in $KERNEL_VERSIONS; do
+		logmust sudo ln -s "/usr/lib/debug/boot/vmlinux-$kernel" "/usr/src/linux-headers-$kernel/vmlinux"
+	done
+}
+
 function delphix_revision() {
 	#
 	# We use "delphix" in the default revision to make it easy to find all

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -24,7 +24,7 @@ function prepare() {
 		debhelper \
 		dpkg-dev \
 		llvm-14
-	logmust install_kernel_headers
+	logmust install_kernel_headers_and_dbgsyms
 	logmust install_pkgs "$DEPDIR"/dwarves/*.deb
 }
 

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -57,7 +57,7 @@ function prepare() {
 		python3 \
 		uuid-dev \
 		zlib1g-dev
-	logmust install_kernel_headers
+	logmust install_kernel_headers_and_dbgsyms
 	logmust install_pkgs "$DEPDIR"/delphix-rust/*.deb
 	logmust cargo install cargo-bundle-licenses@2.1.1 --locked
 	logmust install_pkgs "$DEPDIR"/delphix-go/*.deb


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
When building the ZFS kernel modules, we don't generate BTF due to missing the "vmlinux" at the location expected by the kernel module build system.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to install the "dbgsym" kernel packages which install the "vmlinux" file, and then also add the symlink to that file at the location the kernel module build system expects.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

 - `git-ab-pre-push -b zfs` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11559/)
 
 - With this change, on ESX:
 ```
 $ sudo bpftrace -v /opt/delphix/server/bin/nfs_delete.trace
INFO: node count: 111
Attaching 5 probes...

Program ID: 135

The verifier log:
processed 50 insns (limit 1000000) max_states_per_insn 0 total_states 3 peak_states 3 mark_read 1

Attaching kretfunc:nfsd:nfsd_unlink

Program ID: 136

The verifier log:
processed 2 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

Attaching kfunc:zfs:zfs_ioc_pool_destroy

Program ID: 137

The verifier log:
processed 467 insns (limit 1000000) max_states_per_insn 0 total_states 11 peak_states 11 mark_read 7

Attaching kfunc:vmlinux:vfs_unlink

Program ID: 138

The verifier log:
processed 100 insns (limit 1000000) max_states_per_insn 0 total_states 6 peak_states 6 mark_read 2

Attaching kfunc:nfsd:nfsd_unlink
```
 
</details>
