### PR TITLE
DLPX-96190 [Appliance]  - linux-pkg to use jdk17 for virtualization builds and windows-connector

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -33,7 +33,7 @@ function prepare() {
 
 function build() {
 	export JAVA_HOME
-	JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/"
+	JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64/"
 
 	export LANG
 	LANG=en_US.UTF-8

--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -27,6 +27,7 @@ function prepare() {
 	logmust install_pkgs "${_RET_LIST[@]}"
 
 	logmust install_pkgs \
+		openjdk-17-jdk-headless \
 		"$DEPDIR"/crypt-blowfish/*.deb \
 		"$DEPDIR"/host-jdks/*.deb
 }

--- a/packages/windows-connector/config.sh
+++ b/packages/windows-connector/config.sh
@@ -19,6 +19,11 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dlpx-app-gate.git"
 SKIP_COPYRIGHTS_CHECK=true
 
+function prepare() {
+	logmust install_pkgs \
+		openjdk-17-jdk-headless
+}
+
 function build() {
 	CONNECTOR_DIR="${WORKDIR}/repo/appliance/server/connector"
 	INSTALLER_DIR="${WORKDIR}/repo/appliance/host/windows"


### PR DESCRIPTION
# Description

- Setting JAVA_HOME to JDK 17 for virtualization instead of JDK 8 to enable compatibility with the JDK 17 upgrade in app-gate.
- Installing open jdk 17 for windows connector pkg to enable compatibility with the JDK 17 upgrade in app-gate.

# Testing 
We have been running ab-pre-push twice a week and running regression builds with the images.
Sample ex: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12760/