### PR TITLE
DLPX-94873 [Backport of DLPX-94862] CRA not working on engines upgraded to 2025.4.0.0

### DIFF
--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -26,6 +26,10 @@ function prepare() {
 }
 
 function build() {
+	logmust cd "$WORKDIR/repo/challenge_response/lib"
+	PACKAGE_VERSION=$(date +%Y.%m.%d.%H)
+	logmust set_changelog
+
 	logmust cd "$WORKDIR/repo/challenge_response"
 	logmust make package
 	logmust mv "./$(dpkg-architecture -q DEB_HOST_GNU_CPU)"/*deb "$WORKDIR/artifacts/"


### PR DESCRIPTION
The `pam-challenge-response` package, in its entire history, has always had version
1.0.1, as the package's version was set in a debian changelog file that has
never been updated. As such, it has never been upgraded through any engine
upgrade process, as the apt upgrade process will not upgrade a package whose
new version is identical to its current version (regardless of package
contents). This is the reason why the changes made to this package for the
24.04 Ubuntu update are not applied on upgrade, and why CRA doesn't work once a
system is upgraded to 2025.4.0.0 (because it will still have the previous
`pam-challenge-response` package that doesn't work on Ubuntu 24.04).

The solution is to ensure that the package version gets updated with each build
by leveraging the linux-pkg functionality that is designed to do just that.

### Testing
ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11748/

Installed an external 2025.3.0.1 engine (which has CRA enabled), and upgraded to the upgrade image generated by the above ab-pre-push job. The upgrade was successful and CRA was functional post upgrade:

```
~ ❯ ssh delphix@seb-upgrade.dcol2.delphix.com                                                                                                                  х 255 8m 25s
(delphix@seb-upgrade.dcol2.delphix.com) Engine|Challenge: 09914d56-e9b0-6510-abaa-bf687490be64|71011662
Response:
delphix@localhost:~$ get-appliance-version
2025.4.0.1delphix@localhost:~$ uptime
 00:54:24 up 4 min,  1 user,  load average: 0.12, 0.49, 0.27
delphix@localhost:~$ apt list pam-challenge-response
Listing... Done
pam-challenge-response/now 2025.07.23.22-1delphix.2025.07.23.22.23 amd64 [installed,local]
```
