### PR TITLE
TOOL-28331 kernel module builds fail in install_kernel_headers_and_dbgsyms

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -634,7 +634,7 @@ function install_kernel_headers_and_dbgsyms() {
 	#
 	local kernel
 	for kernel in $KERNEL_VERSIONS; do
-		logmust sudo ln -s "/usr/lib/debug/boot/vmlinux-$kernel" "/usr/src/linux-headers-$kernel/vmlinux"
+		logmust sudo ln -sf "/usr/lib/debug/boot/vmlinux-$kernel" "/usr/src/linux-headers-$kernel/vmlinux"
 	done
 }
 


### PR DESCRIPTION
If we look at the most recent failed jobs to update the linux-kernel-generic package: https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/update-package/job/linux-kernel-generic/234/
The merge itself is clean, but what's failing is the zfs and connstat package builds that are done as part of validating the kernel build. If we look at that connstat build as an example (https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/connstat/job/pre-push/362/console), we see it fails with:

```
05:35:16  Running: sudo ln -s /usr/lib/debug/boot/vmlinux-6.8.0-64-dx2025072406-c2367a020-generic /usr/src/linux-headers-6.8.0-64-dx2025072406-c2367a020-generic/vmlinux
05:35:16  Running: sudo ln -s /usr/lib/debug/boot/vmlinux-6.8.0-1031-dx2025070117-7d1cf60e8-aws /usr/src/linux-headers-6.8.0-1031-dx2025070117-7d1cf60e8-aws/vmlinux
05:35:16  ln: failed to create symbolic link '/usr/src/linux-headers-6.8.0-1031-dx2025070117-7d1cf60e8-aws/vmlinux': File exists
05:35:16  Error: failed command 'sudo ln -s /usr/lib/debug/boot/vmlinux-6.8.0-1031-dx2025070117-7d1cf60e8-aws /usr/src/linux-headers-6.8.0-1031-dx2025070117-7d1cf60e8-aws/vmlinux'
```

The zfs build fails the same way.

The code that issues that `ln -s` call is the `install_kernel_headers_and_dbgsyms()` function in linux-pkg's lib/common.sh file:

```
function install_kernel_headers_and_dbgsyms() {
        logmust install_kernel_headers
        logmust install_kernel_dbgsyms

        #
        # Additionally, we add these symlinks so that kernel module builds will
        # be able to generate BTF information, as they look for the "vmlinux" file
        # in the kernel header directory.
        #
        local kernel
        for kernel in $KERNEL_VERSIONS; do
                logmust sudo ln -s "/usr/lib/debug/boot/vmlinux-$kernel" "/usr/src/linux-headers-$kernel/vmlinux"
        done
}
```

The problem is that we’re building on AWS, and the VM that the build runs on has a pre-existing link created by appliance-build when that base image was created. The linux-pkg code should use ln -sf to overwrite that link.

### Testing

ab-pre-push: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11758/
The above was run from the linux-pkg repo as `git ab-pre-push -b connstat` to show a successfull connstat module build.