### PR TITLE
DLPX-94968 [Backport of DLPX-94858] Delphix Engine NFS Server stops responding under heavy I/O #68

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -99,9 +99,14 @@ function kernel_build() {
 	# Canonical's releases and our releases.
 	#
 	local canonical_abinum delphix_abinum kernel_release kernel_version
+
 	canonical_abinum=$(fakeroot debian/rules printenv | grep -E '^abinum ' | cut -d= -f2 | tr -d '[:space:]')
 	delphix_abinum="${canonical_abinum}-$(date -u +"dx%Y%m%d%H")-$(git rev-parse --short HEAD)"
+
 	kernel_release=$(fakeroot debian/rules printenv | grep -E '^release ' | cut -d= -f2 | tr -d '[:space:]')
+	if [[ -z "$kernel_release" ]]; then
+		kernel_release=$(fakeroot debian/rules printenv | grep -E '^DEB_VERSION_UPSTREAM ' | cut -d= -f2 | tr -d '[:space:]')
+	fi
 
 	#
 	# We record the kernel version into a file. This field is consumed


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

- The logic we use to build the kernel assumes the kernel version can be found in the "release" field, output by "debian/rules printenv". This changed in the new 6.14 kernels, and now that information is found in the "DEB_VERSION_UPSTREAM" field.

- See also: https://github.com/delphix/linux-kernel/oracle/commit/f28fb04c41f29e416570431dd6f9b726356664ed

</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to have our build logic first check the "release" field, but fall back to "DEB_VERSION_UPSTREAM" if the release cannot be found. This way, it should work for kernels prior to 6.14, as well as 6.14+ kernels.
</details>
