### PR TITLE
DLPX-94999 linux-kernel updates to 6.14 are failing

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -99,9 +99,14 @@ function kernel_build() {
 	# Canonical's releases and our releases.
 	#
 	local canonical_abinum delphix_abinum kernel_release kernel_version
+
 	canonical_abinum=$(fakeroot debian/rules printenv | grep -E '^abinum ' | cut -d= -f2 | tr -d '[:space:]')
 	delphix_abinum="${canonical_abinum}-$(date -u +"dx%Y%m%d%H")-$(git rev-parse --short HEAD)"
+
 	kernel_release=$(fakeroot debian/rules printenv | grep -E '^release ' | cut -d= -f2 | tr -d '[:space:]')
+	if [[ -z "$kernel_release" ]]; then
+		kernel_release=$(fakeroot debian/rules printenv | grep -E '^DEB_VERSION_UPSTREAM ' | cut -d= -f2 | tr -d '[:space:]')
+	fi
 
 	#
 	# We record the kernel version into a file. This field is consumed

--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -277,7 +277,7 @@ function kernel_update_upstream() {
 	local tag_prefix_flavour
 	case "${platform}" in
 	generic)
-		tag_prefix_flavour="Ubuntu"
+		tag_prefix_flavour="Ubuntu-hwe"
 		;;
 	aws | azure | gcp | oracle)
 		tag_prefix_flavour="Ubuntu-${platform}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1157,10 +1157,17 @@ function get_kernel_version_for_platform_from_apt() {
 	# for kernel version '4.15.0-1027-aws'. We use this dependency to figure
 	# out the default kernel version for a given platform.
 	#
+	# The "generic" platform is a special case, since we want to use the
+	# hwe kernel image instead of the regular generic image.
+	#
 	# Note that while the default kernel is usually also the latest
 	# available, it is not always the case.
 	#
-	package="linux-image-${platform}"
+	if [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
+		package="linux-image-${platform}"
+	else
+		package="linux-image-${platform}-hwe-24.04"
+	fi
 
 	if [[ "$(apt-cache show --no-all-versions "$package" \
 		2>/dev/null | grep Depends)" =~ linux-image-([^,]*-${platform}) ]]; then


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

- The logic we use to build the kernel assumes the kernel version can be found in the "release" field, output by "debian/rules printenv". This changed in the new 6.14 kernels, and now that information is found in the "DEB_VERSION_UPSTREAM" field.

- See also: https://github.com/delphix/linux-kernel/oracle/commit/f28fb04c41f29e416570431dd6f9b726356664ed

</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to have our build logic first check the "release" field, but fall back to "DEB_VERSION_UPSTREAM" if the release cannot be found. This way, it should work for kernels prior to 6.14, as well as 6.14+ kernels.
</details>

