### PR TITLE
DLPX-95001 use HWE kernel for ESX

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1163,10 +1163,10 @@ function get_kernel_version_for_platform_from_apt() {
 	# Note that while the default kernel is usually also the latest
 	# available, it is not always the case.
 	#
-	if [[ "$platform" != generic ]] && [[ "$UBUNTU_DISTRIBUTION" == focal ]]; then
-		package="linux-image-${platform}"
-	else
+	if [[ "$platform" == generic ]]; then
 		package="linux-image-${platform}-hwe-24.04"
+	else
+		package="linux-image-${platform}"
 	fi
 
 	if [[ "$(apt-cache show --no-all-versions "$package" \


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The recent commit 98e143d was pulling changes from prior to the LTS 24.04 work, to reinstate using the HWE kernel for our generic kernel. The problem is the logic from prior to the LTS had referenced the "focal" ubuntu release, which doesn't work properly now that we've transitioned to the "noble" release.
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution is to simply remove the reference to "focal" entirely.
</details>
