### PR TITLE
DLPX-94862 CRA not working on engines upgraded to 2025.4.0.0

### DIFF
--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -26,6 +26,10 @@ function prepare() {
 }
 
 function build() {
+	logmust cd "$WORKDIR/repo/challenge_response/lib"
+	PACKAGE_VERSION=$(date +%Y.%m.%d.%H)
+	logmust set_changelog
+
 	logmust cd "$WORKDIR/repo/challenge_response"
 	logmust make package
 	logmust mv "./$(dpkg-architecture -q DEB_HOST_GNU_CPU)"/*deb "$WORKDIR/artifacts/"


### PR DESCRIPTION
This is a clean forward-port cherry-pick of #361 that was done for the 2025.4.0.1 patch release on the patch branch.
