### PR TITLE
DLPX-95062 simplify challenge-response package build

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1087,8 +1087,23 @@ function push_to_remote() {
 #
 function set_changelog() {
 	check_env PACKAGE_REVISION
-	local src_package="${1:-$PACKAGE}"
 	local final_version
+
+	#
+	# If the name of the source package isn't passed in as a parameter,
+	# then deduce it. If there's a debian/control file that specifies that
+	# package name, then use it. Otherwise, default to the name of the
+	# linux-pkg directory name. This can't always be the default because
+	# for some packages, those are different.  For example, the
+	# challenge-response linux-pkg directory generates the
+	# pam-challenge-response debian package.
+	#
+	if [[ -n $1 ]]; then
+		src_package=$1
+	elif [[ -f debian/control ]]; then
+		src_package=$(awk '/^Source:/ { print $2 }' debian/control)
+	fi
+	src_package=${src_package:-$PACKAGE}
 
 	#
 	# If PACKAGE_VERSION hasn't been set already, then retrieve it from

--- a/packages/challenge-response/config.sh
+++ b/packages/challenge-response/config.sh
@@ -19,18 +19,9 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/challenge-response.git"
 
 function prepare() {
-	logmust install_pkgs \
-		libpam0g-dev \
-		libssl-dev \
-		uuid-dev
+	install_build_deps_from_control_file
 }
 
 function build() {
-	logmust cd "$WORKDIR/repo/challenge_response/lib"
-	PACKAGE_VERSION=$(date +%Y.%m.%d.%H)
-	logmust set_changelog
-
-	logmust cd "$WORKDIR/repo/challenge_response"
-	logmust make package
-	logmust mv "./$(dpkg-architecture -q DEB_HOST_GNU_CPU)"/*deb "$WORKDIR/artifacts/"
+	dpkg_buildpackage_default
 }


### PR DESCRIPTION
The challenge-response linux-pkg package build is needlessly complex. The linux-pkg framework provides a set of default functions for performing the most common tasks:

1. Installing dependencies in the prepare phase using information from the debian control file (`install_build_deps_from_control_file`)
2. Building the package using standard debian tooling (`dpkg_buildpackage_default`)

Instead of using these convenience functions, the challenge-response package uses its own set of custom commands and Makefile-based build (which itself calls into debian commands). This can be simplified.

This PR is inter-dependent with https://www.github.com/delphix/challenge-response/pull/9.

The output of this package build is a debian file with the following format and contents:
```
delphix@ip-10-110-206-237:~/linux-pkg$ dpkg -c packages/challenge-response/tmp/artifacts/pam-challenge-response_1.0.0-1delphix.2025.08.08.19.15_amd64.deb
drwxr-xr-x root/root         0 2025-08-08 19:16 ./
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/lib/
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/lib/x86_64-linux-gnu/
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/lib/x86_64-linux-gnu/security/
-rw-r--r-- root/root     18704 2025-08-08 19:16 ./usr/lib/x86_64-linux-gnu/security/pam_challenge_response.so
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/share/
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/share/doc/
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/share/doc/pam-challenge-response/
-rw-r--r-- root/root       187 2025-08-08 19:16 ./usr/share/doc/pam-challenge-response/changelog.Debian.gz
-rw-r--r-- root/root       152 2025-08-08 19:16 ./usr/share/doc/pam-challenge-response/copyright
drwxr-xr-x root/root         0 2025-08-08 19:16 ./usr/share/pam-configs/
-rw-r--r-- root/root       162 2025-08-08 19:16 ./usr/share/pam-configs/challenge-response
```

ab-pre-push (contains changes for both inter-dependent PRs): https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11888/

The upgrade test failed, but upgrades to develop are generally broken right now. I did verify that the pam-challenge-response module is correctly upgraded in the verify container. Something else is broken with upgrade verify (unrelated to this change).