### PR TITLE
CP-12693 Sign kernel modules and image during kernel build (no shim) CP-12694 Sign ZFS modules after ZFS build (no shim) CP-12695 Sign connstat module after build (no shim)

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -161,6 +161,44 @@ function kernel_build() {
 	logmust fakeroot debian/rules printenv "${debian_rules_args[@]}"
 
 	#
+	# Configure signing keys/certs before build
+	#
+	# CONFIG_MODULE_SIG_KEY is set to /var/tmp/sbkeys/signing_key.pem in
+	# resources/delphix_kernel_annotations
+	#
+	FLAVOUR=$platform
+	OBJ=debian/build/build-$FLAVOUR
+	CERTS=$OBJ/certs
+
+	# ensure the objdir + certs dir exist
+	mkdir -p "$CERTS"
+	download_keys
+
+	# provide the key the packaging expects INSIDE the objdir
+	# (symlink or copy)
+	logmust ln -sf "${SB_KEYS_DIR}/signing_key.pem" "$CERTS/signing_key.pem"
+	logmust chmod 600 "$CERTS/signing_key.pem"
+
+	# create the DER .x509 that sign-file needs from .crt)
+	logmust openssl x509 -in "${SB_KEYS_DIR}/db.crt" -outform DER -out "$CERTS/signing_key.x509"
+
+	# sanity checks
+	logmust test -s "$CERTS/signing_key.pem" || {
+		echo "missing signing_key.pem"
+		exit 1
+	}
+	logmust test -s "$CERTS/signing_key.x509" || {
+		echo "missing signing_key.x509"
+		exit 1
+	}
+	logmust openssl pkey -in "$CERTS/signing_key.pem" -noout >/dev/null || {
+		echo "key unreadable"
+		exit 1
+	}
+	SBSIGN_KEY="${SBSIGN_KEY:-$SB_KEYS_DIR/db.key}"
+	SBSIGN_CERT="${SBSIGN_CERT:-$SB_KEYS_DIR/db.crt}"
+
+	#
 	# The default value of the tool argument for mk-build-deps
 	# is the following:
 	# "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends"
@@ -203,6 +241,23 @@ function kernel_build() {
 	# one of the .debs produced
 	#
 	logmust test -f "artifacts/linux-image-${kernel_version}_"*.deb
+
+	#
+	# After the build, unpackage linux-image package and sign vmlinuz
+	#
+	linux_deb=$(find artifacts -type f -name "linux-image-${kernel_version}*.deb" | head -n1)
+	temp_dir=$(mktemp -d -p "/var/tmp/")
+	logmust fakeroot dpkg-deb -R $linux_deb "$temp_dir"
+
+	bz="$temp_dir/boot/vmlinuz-${kernel_version}"
+	logmust sbsign --key $SBSIGN_KEY --cert $SBSIGN_CERT --output "$bz.signed" "$bz"
+	logmust mv "$bz.signed" "$bz"
+	logmust sbverify --list "$bz"
+
+	# Repack the .deb"
+	update_md5sums "$temp_dir"
+	repack_deb $linux_deb $temp_dir
+	delete_keys
 }
 
 #

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1414,3 +1414,87 @@ function set_secret_build_args() {
 		_SECRET_BUILD_ARGS+=("-DSECRET_DB_AWS_REGION=$SECRET_DB_AWS_REGION")
 	fi
 }
+
+#
+# Secure boot variables and functions
+#
+# S3 bucket containing keys and certs
+# ./db subdirectory contains the db key and various certs:
+#   .der is for signing modules like ZFS and connstat
+#   .crt is for signing vmlinuz
+#   signing_key.pem is the format expected by kernel build for signing its modules
+#
+# ./pub contains the auth files, secure boot enrollment certs.
+#
+S3_KEYS_URL="s3://secure-boot-keys-prod/release"
+#
+# The kernel build expects the signing_key.pem in this directory, i.e.
+# CONFIG_MODULE_SIG_KEY is set to /var/tmp/sbkeys/signing_key.pem in
+# resources/delphix_kernel_annotations
+#
+SB_KEYS_DIR="/var/tmp/sbkeys"
+SBSIGN_KEY="$SB_KEYS_DIR/db.key"
+SBSIGN_DER="$SB_KEYS_DIR/db.der"
+
+function download_keys() {
+	logmust mkdir -p $SB_KEYS_DIR
+	logmust aws s3 cp --recursive "$S3_KEYS_URL/db/" $SB_KEYS_DIR
+}
+
+function delete_keys() {
+	logmust rm -r $SB_KEYS_DIR
+}
+
+# Update DEBIAN/md5sum for package directory after
+# some files were updated, i.e. secure-boot signed.
+#
+function update_md5sums() {
+	pkg_dir=$1
+	echo_bold "Updating md5sums for $pkg_dir"
+
+	(
+		cd "$pkg_dir" || exit
+		: >DEBIAN/md5sums
+		# print paths relative to root of package
+		while IFS= read -r -d '' f; do
+			rel="${f#./}"
+			md5sum "$rel" >>DEBIAN/md5sums
+		done < <(find . -type f ! -path './DEBIAN/*' ! -path './etc/depmod*' -print0)
+	)
+}
+
+function repack_deb() {
+	deb_name=$1
+	deb_dir=$2
+	temp_deb=$(mktemp /tmp/deb.XXXXXX)
+
+	logmust fakeroot dpkg-deb -b "$deb_dir" "$temp_deb"
+	logmust mv "$temp_deb" "$deb_name"
+}
+
+#
+# Sign .ko files in the module list
+#
+function sign_modules() {
+	deb_pkgs="$1"
+	echo_bold "Signing $deb_pkgs"
+	download_keys
+
+	while IFS= read -r pkg; do
+		echo_bold "Processing $pkg"
+		temp_dir=$(mktemp -d -p "/var/tmp/")
+		logmust fakeroot dpkg-deb -R "$pkg" "$temp_dir"
+
+		# Find and sign all .ko files in package
+		find "$temp_dir" -type f -name "*.ko" -print0 |
+			while IFS= read -r -d '' kernel_mod; do
+				logmust kmodsign sha256 "$SBSIGN_KEY" "$SBSIGN_DER" "$kernel_mod" "$kernel_mod.signed"
+				logmust mv "$kernel_mod.signed" "$kernel_mod"
+				logmust modinfo -F signer "$kernel_mod"
+			done
+		# Repack the .deb"
+		update_md5sums "$temp_dir"
+		repack_deb "$pkg" "$temp_dir"
+	done <<<"$deb_pkgs"
+	delete_keys
+}

--- a/packages/connstat/config.sh
+++ b/packages/connstat/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,4 +50,8 @@ function build() {
 
 	logmust cd "$WORKDIR/repo"
 	logmust mv ./*deb "$WORKDIR/artifacts/"
+
+	# Sign the generated modules
+	connstat_pkgs=$(find "$WORKDIR/artifacts" -type f -name "connstat-module-*.deb" ! -name "*-dbg*")
+	sign_modules "$connstat_pkgs"
 }

--- a/packages/zfs/config.sh
+++ b/packages/zfs/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2019, 2020 Delphix
+# Copyright 2019, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -174,6 +174,10 @@ function build() {
 	done
 	logmust cd "$WORKDIR"
 	logmust mv "all-packages/"*.deb "artifacts/"
+
+	# Sign ZFS modules in all packages
+	zfs_pkgs=$(find "$WORKDIR/artifacts" -type f -name "zfs-modules-*.deb" ! -name "*-dbg*")
+	sign_modules "$zfs_pkgs"
 }
 
 function update_upstream() {

--- a/resources/delphix_kernel_annotations
+++ b/resources/delphix_kernel_annotations
@@ -2,6 +2,9 @@
 # FORMAT: 4
 # ARCH: amd64
 # FLAVOUR: amd64-aws amd64-azure amd64-generic amd64-gcp amd64-oracle
+#
+CONFIG_MODULE_SIG_KEY  		policy<{'amd64': '"/var/tmp/sbkeys/signing_key.pem"'}>
+CONFIG_MODULE_SIG_FORCE 			policy<{'amd64': 'y', 'arm64': 'n'}>
 
 #
 # Disable various "net" modules which we don't use.


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>
With Secure Boot, kernel image and modules needs to be be signed so that they can be verified on boot.
</details>

<!--
<details open>
<summary><h2> Problem </h2></summary>

Provide a clear description of the high-level problem you are trying to
solve. The problem statement should be written in terms of a specific
symptom that affects users or the business. The problem statement should
not be written in terms of the solution. If possible, include a minimal
reproducible example (MRE) with steps to reproduce, expected results,
and actual results.
</details>
-->

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
The changes here updated the following package builds:

1. linux-kernel-* - includes CONFIG_MODULE_SIG_FORCE and CONFIG_MODULE_SIG_KEY such that kernel build uses our keys to sign modules. Also, signs vmlinuz after the build since kernel build does NOT sign kernel image.
2. ZFS - signs zfs.ko and spl.ko for all generated deb packages after the build 
3. connstat - signs connstat.ko for all generated deb packages after the build

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- Successful appliance builds for ESX, AWS, GCP, and Azure which imported created images and successfully booted VMs on those cloud platforms.
- On AWS, upgrade blackbox test also ran successfully.

Last successful build (08/23) - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11986/

Current build (08/25) - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/11996/console

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
