### PR TITLE
DLPX-95179 libkdumpfile's upstream is no longer on github

### DIFF
--- a/packages/libkdumpfile/config.sh
+++ b/packages/libkdumpfile/config.sh
@@ -18,7 +18,7 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/libkdumpfile.git"
 
-UPSTREAM_GIT_URL="https://github.com/ptesarik/libkdumpfile.git"
+UPSTREAM_GIT_URL="https://codeberg.org/ptesarik/libkdumpfile.git"
 UPSTREAM_GIT_BRANCH="tip"
 
 function prepare() {


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The upstream libkdumpfile activity has moved off of github, but we haven't updated our linux-pkg config to point to the new location.
</details>

<details open>
<summary><h2> Solution </h2></summary>
Update the package config to point to the new location where upstream is doing development on libdumpfile.
</details>
