### PR TITLE
DLPX-95924 [Backport of DLPX-95843] Ubuntu Security Notification for runC Vulnerabilities (USN-7851-1)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -47,7 +47,10 @@ SKIP_COPYRIGHTS_CHECK=true
 function fetch() {
 	logmust cd "$WORKDIR/artifacts"
 
-	local debs=()
+	local debs=(
+		# Used "apt-get download runc" on "develop" to obtain this package.
+		"runc_1.3.3-0ubuntu1~24.04.2_amd64.deb 1e45145fa8b45b12ce95bf8f65ff737f159a32c3490367b97d65132d6d9a19f5"
+	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"
 


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>
The runc package version currently on release is 1.3.0, and subject to a security vulnerability.

See also: https://nvd.nist.gov/vuln/detail/CVE-2025-31133
</details>

<details open>
<summary><h2> Solution </h2></summary>
The solution taken in this PR is to use the runc package from "develop" which has a fix for this vulnerability.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- `git-ab-pre-push -b misc-debs` is [here](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/12557/)

- Manually installed new `runc` package on release based engine.. e.g.
```
$ dpkg -l | grep runc
ii  runc                                                       1.3.0-0ubuntu2~24.04.1                           amd64        Open Container Project - runtime

$ sudo apt-get install ./runc_1.3.3-0ubuntu1~24.04.2_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'runc' instead of './runc_1.3.3-0ubuntu1~24.04.2_amd64.deb'
The following packages will be upgraded:
  runc
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/8,815 kB of archives.
After this operation, 315 kB of additional disk space will be used.
Get:1 /export/home/delphix/runc_1.3.3-0ubuntu1~24.04.2_amd64.deb runc amd64 1.3.3-0ubuntu1~24.04.2 [8,815 kB]
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 210648 files and directories currently installed.)
Preparing to unpack .../runc_1.3.3-0ubuntu1~24.04.2_amd64.deb ...
Unpacking runc (1.3.3-0ubuntu1~24.04.2) over (1.3.0-0ubuntu2~24.04.1) ...
Setting up runc (1.3.3-0ubuntu1~24.04.2) ...
Processing triggers for man-db (2.12.0-4build2) ...

$ dpkg -l | grep runc
ii  runc                                                       1.3.3-0ubuntu1~24.04.2                           amd64        Open Container Project - runtime

$ get-appliance-version
2025.6.0.0
```

</details>
