### PR TITLE
CP-13121 Add stable to the ppas mirror URL in the linux-pkg

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2025 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ function configure_apt_sources() {
 		deb ${primary_url} ${UBUNTU_DISTRIBUTION}-backports main restricted universe multiverse
 		deb-src ${primary_url} ${UBUNTU_DISTRIBUTION}-backports main restricted universe multiverse
 
-		deb ${secondary_url} ${UBUNTU_DISTRIBUTION} main multiverse universe
+		deb ${secondary_url} ${UBUNTU_DISTRIBUTION} main multiverse universe stable
 		EOF" || die "/etc/apt/sources.list could not be updated"
 
 	logmust sudo apt-key add "$TOP/resources/delphix-secondary-mirror.key"


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

As part of updating docker packages to official packages docker-ce, we found out that the ppas secondary URL from the linux-pkg does not contain the stable path where docker-ce, docker-cli and [containerd.io](http://containerd.io/) are hosted.

Example URL 

- http://linux-package-mirror-v2.delphix.com/releases/2026.1.0.0/ppas/pool/stable/d/
- http://linux-package-mirror-v2.delphix.com/develop/fe18920c/ppas/pool/stable/d/

</details>

<details open>
<summary><h2> Solution </h2></summary>

Added "stable" to the secondary URL, so that the docker-ce can be picked up after apt-get update.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

- [ab-pre-push](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13042/)
- delphix-platform which uses the setup.sh
    - Without changes - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/delphix-platform/job/pre-push/1067/consoleFull<img width="1400" height="639" alt="Screenshot 2026-01-23 at 2 21 37 PM" src="https://github.com/user-attachments/assets/6ee2ef10-c2a6-4ff9-b3f1-7b3bb663d46c" />
    - With Changes - https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/delphix-platform/job/pre-push/1073/consoleFull<img width="1371" height="598" alt="Screenshot 2026-01-23 at 2 22 28 PM" src="https://github.com/user-attachments/assets/29e60469-4840-42d7-aef9-bec3c0098dfd" />


</details>