### PR TITLE
DLPX-96562 eliminate docker from the delphix-platform package build

### DIFF
--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -24,7 +24,7 @@ function prepare() {
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust make packages
+	logmust make packages VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -19,6 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
 function prepare() {
+	logmust cd "$WORKDIR/repo"
 	logmust sudo make build-deps
 }
 

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -18,6 +18,10 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
 function build() {
 	logmust cd "$WORKDIR/repo"
 	logmust ansible-playbook bootstrap/playbook.yml

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -18,11 +18,6 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
-function prepare() {
-	logmust cd "$WORKDIR/repo"
-	logmust sudo make build-deps
-}
-
 function build() {
 	logmust cd "$WORKDIR/repo"
 	logmust make packages VERSION="1.0.0-$PACKAGE_REVISION"

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -20,7 +20,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust make packages VERSION="1.0.0-$PACKAGE_REVISION"
+	logmust sudo make packages VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2018, 2020 Delphix
+# Copyright 2018, 2026 Delphix
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 function build() {
 	logmust cd "$WORKDIR/repo"
 	logmust ansible-playbook bootstrap/playbook.yml
-	logmust ./scripts/docker-run.sh make packages \
-		VERSION="1.0.0-$PACKAGE_REVISION"
+	logmust make packages
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -19,7 +19,7 @@
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
 function prepare() {
-	logmust install_build_deps_from_control_file
+	logmust sudo make build-deps
 }
 
 function build() {

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -18,9 +18,14 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
+function prepare() {
+	logmust cd "$WORKDIR/repo"
+	logmust sudo make build-deps
+}
+
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust sudo make packages VERSION="1.0.0-$PACKAGE_REVISION"
+	logmust make packages VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
 }

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -24,7 +24,6 @@ function prepare() {
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust ansible-playbook bootstrap/playbook.yml
 	logmust make packages
 	logmust sudo chown -R "$USER:" artifacts
 	logmust mv artifacts/*deb "$WORKDIR/artifacts/"

--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -25,7 +25,7 @@ function prepare() {
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust make packages VERSION="1.0.0-$PACKAGE_REVISION"
+	logmust sudo make packages VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
-	logmust mv artifacts/*deb "$WORKDIR/artifacts/"
+	logmust sudo mv artifacts/*deb "$WORKDIR/artifacts/"
 }


### PR DESCRIPTION
See the Jira description for details. This PR is interdependent with delphix-platform PR https://github.com/delphix/delphix-platform/pull/555 and must be tested and integrated together.

linux-pkg build of delphix-platform package: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/delphix-platform/job/pre-push/1117/
