### PR TITLE
DLPX-96583 Re-adding delphix/bcc package to linux-pkg

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -2,6 +2,7 @@
 # List of non-kernel packages to be included in the Delphix Appliance.
 #
 
+bcc
 challenge-response
 cloud-init
 crash-python

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+#
+#
+# DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bcc.git"
+DEFAULT_PACKAGE_GIT_URL="https://github.com/tonynguien/bcc.git" # for development
+
+UPSTREAM_GIT_URL=https://github.com/iovisor/bcc.git
+UPSTREAM_GIT_BRANCH=master
+
+function prepare() {
+	echo 'Install build dependencies'
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

estat commands with zfs headers are failing, i.e. estat zio | zil | zpl | zvol | nfs-by-client | metaslab-alloc, see https://perforce.atlassian.net/browse/DLPX-96293.

The problem is Ubuntu bpfcc-tools and related packages the two years old, version 0.29, and support up to the 6.8 kernel (the main Ubuntu 24.04). Our images are running 6.14 kernel thus we get below forward declaration error

```
In file included from include/linux/security.h:35:
include/linux/bpf.h:352:10: error: invalid application of 'sizeof' to an incomplete type 'struct bpf_wq'
  352 |                 return sizeof(struct bpf_wq);
      |                        ^     ~~~~~~~~~~~~~~~
include/linux/bpf.h:352:24: note: forward declaration of 'struct bpf_wq'
  352 |                 return sizeof(struct bpf_wq);
      |                                      ^
include/linux/bpf.h:382:10: error: invalid application of '__alignof' to an incomplete type 'struct bpf_wq'
  382 |                 return __alignof__(struct bpf_wq);
      |                        ^          ~~~~~~~~~~~~~~~
include/linux/bpf.h:382:29: note: forward declaration of 'struct bpf_wq'
  382 |                 return __alignof__(struct bpf_wq);
      |                                           ^
4 warnings and 2 errors generated.
Traceback (most recent call last):
  File "/usr/share/performance-diagnostics/bpf/standalone/zil.py", line 316, in <module>
    b = BPF(text=bpf_text,
        ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 479, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
```
I’ve verified that a recent build of iovisor/bcc works cleanly and we no longer get these warning/error.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

The proposed solution is to build our own bcc/bpfcc packages using upstream iovisor/bcc repo which is what we did (see https://github.com/delphix/bcc)  prior to 24.04 LTS. Our delphix/bcc repo is not current, last major merge was Jan 2022. 

This PR will re-enable bcc package though using my private repo for development. The Debian files have not been maintained so there are minor build and packaging rules updates so we can cleanly build and replace Ubuntu packages.

Follow up PRs will make the delphix/bcc repo current with additional Debian/build changes and set  DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bcc.git"
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

Successful bcc package build
```
./buildpkg.sh -b master bcc 2>&1| tee build.1
Running: check_running_system
Running: run_setup_if_needed
Running: check_package_exists bcc

====================================================================
                     PACKAGE bcc
====================================================================

Running: load_package_config bcc
Running: check_package_exists bcc
Running: reset_package_config_variables
Running: source /export/home/delphix/linux-pkg/default-package-config.sh
Running: source /export/home/delphix/linux-pkg/packages/bcc/config.sh
Running: get_package_prefix bcc
Running: get_package_config_from_env
get_package_config_from_env(): using prefix: BCC_
PACKAGE_GIT_URL set to value of DEFAULT_PACKAGE_GIT_URL
PARAM_PACKAGE_GIT_BRANCH passed from '-b'
PACKAGE_REVISION set to value of DEFAULT_REVISION
------------------------------------------------------------
PACKAGE_GIT_URL:      https://github.com/tonynguien/bcc.git
PACKAGE_GIT_BRANCH:   master
PACKAGE_REVISION:     delphix.2026.02.13.18.16
------------------------------------------------------------
Running: create_workdir
Running: sudo rm -rf /export/home/delphix/linux-pkg/packages/bcc/tmp
Running: mkdir /export/home/delphix/linux-pkg/packages/bcc/tmp
Running: rm -f /export/home/delphix/linux-pkg/workdir
Running: ln -s /export/home/delphix/linux-pkg/packages/bcc/tmp /export/home/delphix/linux-pkg/workdir
Running: mkdir /export/home/delphix/linux-pkg/packages/bcc/tmp/artifacts
Running: cd /export/home/delphix/linux-pkg/packages/bcc/tmp
....
....
PACKAGE bcc: STAGE post_build_checks STARTED
Running: post_build_checks
Running: dpkg-deb -c bpfcc-lua_0.36.0-1+delphix.2026.02.13.18.16_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-13 18:16 ./usr/share/doc/bpfcc-lua/copyright
Running: dpkg-deb -c bpfcc-tools_0.36.0-1+delphix.2026.02.13.18.16_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-13 18:16 ./usr/share/doc/bpfcc-tools/copyright
Running: dpkg-deb -c libbpfcc-examples_0.36.0-1+delphix.2026.02.13.18.16_amd64.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-13 18:16 ./usr/share/doc/libbpfcc-examples/copyright
Running: dpkg-deb -c libbpfcc_0.36.0-1+delphix.2026.02.13.18.16_amd64.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-13 18:16 ./usr/share/doc/libbpfcc/copyright
Running: dpkg-deb -c python3-bpfcc_0.36.0-1+delphix.2026.02.13.18.16_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-13 18:16 ./usr/share/doc/python3-bpfcc/copyright
PACKAGE bcc: STAGE post_build_checks COMPLETED in 1 seconds

Success: Package bcc has been built successfully.
Build products are in /export/home/delphix/linux-pkg/packages/bcc/tmp/artifacts
```

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
