### PR TITLE
DLPX-96589 2026.2 signatures missing in the develop (2026.2.0.0) image

### DIFF
--- a/packages/delphix-platform/config.sh
+++ b/packages/delphix-platform/config.sh
@@ -20,12 +20,12 @@ DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/delphix-platform.git"
 
 function prepare() {
 	logmust cd "$WORKDIR/repo"
-	logmust sudo make build-deps
+	logmust sudo -E make build-deps
 }
 
 function build() {
 	logmust cd "$WORKDIR/repo"
-	logmust sudo make packages VERSION="1.0.0-$PACKAGE_REVISION"
+	logmust sudo -E make packages VERSION="1.0.0-$PACKAGE_REVISION"
 	logmust sudo chown -R "$USER:" artifacts
 	logmust sudo mv artifacts/*deb "$WORKDIR/artifacts/"
 }


### PR DESCRIPTION
PR #382 changed the build from using docker to using the make command-line directly. As part of this change, the build was changed to be run as root under `sudo`. The `sudo` command doesn't preserve the environment by default. The `-E` option should be used if enviroment variables need to be preserved.

Testing: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/build-package/job/delphix-platform/job/pre-push/1123/

The "key" thing to note in this job's console is this output block:
```
18:21:30  for type in registration upgrade ; do \
18:21:30  	./scripts/download-signature-key.sh $type "2026.2" \
18:21:30  	>"debian/tmp/var/lib/delphix-appliance/key-public.pem.$type.2026.2" ; done
```
Note the output public key has the "2026.2" version as its suffix, which is what we want.