### PR TITLE
DLPX-96466 hv_kvp_daemon incorrectly calls hv_get_dhcp_info and hv_get_dns_info from /usr/libexec/hypervkvpd/

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -135,7 +135,7 @@ function kernel_build() {
 	#
 	local debian_rules_args=(
 		"do_dbgsym_package=true"
-		"do_tools_common=true"
+		"do_tools_common=false"
 		"do_tools_host=false"
 		"uefi_signed=false"
 		"do_zfs=false"

--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -135,7 +135,7 @@ function kernel_build() {
 	#
 	local debian_rules_args=(
 		"do_dbgsym_package=true"
-		"do_tools_common=false"
+		"do_tools_common=true"
 		"do_tools_host=false"
 		"uefi_signed=false"
 		"do_zfs=false"

--- a/packages/linux-kernel-azure/config.delphix.sh
+++ b/packages/linux-kernel-azure/config.delphix.sh
@@ -38,7 +38,7 @@ function prepare() {
 }
 
 function build() {
-	logmust kernel_build "azure"
+	logmust kernel_build "azure" "do_tools_common=true"
 }
 
 function update_upstream() {


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

Allow us to build the tools_common packages. Currently, they are not built.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Set up the debian rules to build the tools common packages when building the linux-kernel-azure package.
</details>


<details>
<summary><h2> Testing Done </h2></summary>

root@localhost:~# strings /usr/lib/linux-tools/6.14.0-1017-dx2026022417-4e8265c4a-azure/hv_kvp_daemon | grep sbin
/usr/sbin/hv_get_dns_info
/usr/sbin/hv_get_dhcp_info
/usr/sbin/hv_set_ifconfig
root@localhost:~# systemctl status hv-kvp-daemon
● hv-kvp-daemon.service - Hyper-V KVP Protocol Daemon
     Loaded: loaded (/usr/lib/systemd/system/hv-kvp-daemon.service; enabled; preset: enabled)
     Active: active (running) since Wed 2026-02-25 00:16:10 UTC; 9min ago
   Main PID: 578 (hv_kvp_daemon)
      Tasks: 1 (limit: 8753)
     Memory: 424.0K (peak: 1.3M)
        CPU: 16ms
     CGroup: /system.slice/hv-kvp-daemon.service
             └─578 /usr/lib/linux-tools/6.14.0-1017-dx2026022417-4e8265c4a-azure/hv_kvp_daemon -n

Feb 25 00:16:10 localhost.localdomain systemd[1]: Started hv-kvp-daemon.service - Hyper-V KVP Protocol Daemon.
Feb 25 00:16:10 localhost.localdomain KVP[578]: KVP starting; pid is:578
Feb 25 00:16:10 localhost.localdomain KVP[578]: KVP LIC Version: 3.1
</details>
