### PR TITLE
DLPX-96594 fix linux-kernel-generic upstream merge for 6.17

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -122,6 +122,9 @@ function kernel_build() {
 	# do_tools_common=false
 	#   We do not need to build linux-tools-common package and we
 	#   install it directly from our package mirror.
+	# do_tools_perf=false
+	#   The perf tool is provided by the linux-tools-common package,
+	#   which we install directly from our package mirror.
 	# do_tools_host=false
 	#   We do not need to build linux-tools-host package.
 	# uefi_signed=false
@@ -136,6 +139,7 @@ function kernel_build() {
 	local debian_rules_args=(
 		"do_dbgsym_package=true"
 		"do_tools_common=false"
+		"do_tools_perf=false"
 		"do_tools_host=false"
 		"uefi_signed=false"
 		"do_zfs=false"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

After updating to kernel 6.17, linux-kernel-generic was failing to build the `perf` tool with:
<code>
15:14:09  mmap.c: In function ‘perf_mmap__read’:
15:14:09  mmap.c:217:38: error: invalid use of undefined type ‘union perf_event’
15:14:09    217 |         if (diff >= (int)sizeof(event->header)) {
15:14:09        |                                      ^~
15:14:09  mmap.c:221:29: error: invalid use of undefined type ‘union perf_event’
15:14:09    221 |                 size = event->header.size;
15:14:09        |                             ^~
15:14:09  mmap.c:223:40: error: invalid use of undefined type ‘union perf_event’
15:14:09    223 |                 if (size < sizeof(event->header) || diff < (int)size)
15:14:09        |                                        ^~
15:14:09  make[5]: *** [/export/home/delphix/jenkins/workspace/linux-pkg/develop/build-package/linux-kernel-generic/pre-push/linux-pkg/packages/linux-kernel-generic/tmp/repo/debian/build/tools-perarch/tools/build/Makefile.build:86: /export/home/delphix/jenkins/workspace/linux-pkg/develop/build-package/linux-kernel-generic/pre-push/linux-pkg/packages/linux-kernel-generic/tmp/repo/debian/build/tools-perarch/tools/perf/libperf/mmap.o] Error 1
</code>
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>
I did not root-cause the perf compilation failure. However, in default-package-config.sh we have:

>        # do_tools_common=false
>        #   We do not need to build linux-tools-common package and we
>        #   install it directly from our package mirror.

We don't have any custom modifications to `perf`, and it is provided by linux-tools-common, so we don't need to be building it. This PR adds `do_tools_perf=false`.  
</details>


<details>
<summary><h2> Testing Done </h2></summary>
https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/13331/

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
