### PR TITLE
DLPX-96700 Re-enable delphix/bcc package to linux-pkg

### DIFF
--- a/package-lists/build/main.pkgs
+++ b/package-lists/build/main.pkgs
@@ -2,6 +2,7 @@
 # List of non-kernel packages to be included in the Delphix Appliance.
 #
 
+bcc
 challenge-response
 cloud-init
 crash-python

--- a/packages/bcc/config.sh
+++ b/packages/bcc/config.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# shellcheck disable=SC2034
+
+DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/bcc.git"
+
+UPSTREAM_GIT_URL=https://github.com/iovisor/bcc.git
+UPSTREAM_GIT_BRANCH=master
+
+function prepare() {
+	logmust install_build_deps_from_control_file
+}
+
+function build() {
+	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
+}


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

This is a second attempt of https://github.com/delphix/linux-pkg/pull/383 and I've tested with the updated delphix/bcc repo, see https://github.com/delphix/bcc/pull/20

</details>

<details open>
<summary><h2> Problem </h2></summary>

estat commands with zfs headers are failing, i.e. estat zio | zil | zpl | zvol | nfs-by-client | metaslab-alloc, see https://perforce.atlassian.net/browse/DLPX-96293.

The problem is Ubuntu bpfcc-tools and related packages the two years old, version 0.29, and support up to the 6.8 kernel (the main Ubuntu 24.04). Our images are running 6.14 kernel thus we get below forward declaration error

```
In file included from include/linux/security.h:35:
include/linux/bpf.h:352:10: error: invalid application of 'sizeof' to an incomplete type 'struct bpf_wq'
  352 |                 return sizeof(struct bpf_wq);
      |                        ^     ~~~~~~~~~~~~~~~
include/linux/bpf.h:352:24: note: forward declaration of 'struct bpf_wq'
  352 |                 return sizeof(struct bpf_wq);
      |                                      ^
include/linux/bpf.h:382:10: error: invalid application of '__alignof' to an incomplete type 'struct bpf_wq'
  382 |                 return __alignof__(struct bpf_wq);
      |                        ^          ~~~~~~~~~~~~~~~
include/linux/bpf.h:382:29: note: forward declaration of 'struct bpf_wq'
  382 |                 return __alignof__(struct bpf_wq);
      |                                           ^
4 warnings and 2 errors generated.
Traceback (most recent call last):
  File "/usr/share/performance-diagnostics/bpf/standalone/zil.py", line 316, in <module>
    b = BPF(text=bpf_text,
        ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 479, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
```

I’ve verified that a recent build of iovisor/bcc works cleanly and we no longer get these warning/error.

</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

The solution is to build our own bcc packages which is what we did prior to the upgrade to 24.04 LTS. The  delphix/bcc is a couple years out of date so the related https://github.com/delphix/bcc/pull/20 PR updates that repo and adds minor changes to properly build and rename Debian packages so they can cleanly replace Ubuntu *bpfcc* packages.

</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Successful build against the delphix/bcc with merge changes.
```
delphix@ip-10-110-243-71:~ export DEFAULT_GIT_BRANCH=dlpx/pr/tonynguien/5047efc9-172e-480b-80ce-86a59c7935e7
delphix@ip-10-110-243-71:~ export DELPHIX_RELEASE_VERSION=2026.1.0.0
delphix@ip-10-110-243-71:~ ./buildpkg.sh bcc 2>&1 | tee build.delphix
delphix@ip-10-110-243-71:~/linux-pkg$ tail -n20 build.delphix

Running: cd /export/home/delphix/linux-pkg/packages/bcc/tmp

PACKAGE bcc: STAGE post_build_checks STARTED
Running: post_build_checks
Running: dpkg-deb -c bpfcc-lua_0.36.1-1+delphix.2026.02.27.22.53_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-27 22:53 ./usr/share/doc/bpfcc-lua/copyright
Running: dpkg-deb -c bpfcc-tools_0.36.1-1+delphix.2026.02.27.22.53_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-27 22:53 ./usr/share/doc/bpfcc-tools/copyright
Running: dpkg-deb -c libbpfcc-examples_0.36.1-1+delphix.2026.02.27.22.53_amd64.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-27 22:53 ./usr/share/doc/libbpfcc-examples/copyright
Running: dpkg-deb -c libbpfcc_0.36.1-1+delphix.2026.02.27.22.53_amd64.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-27 22:53 ./usr/share/doc/libbpfcc/copyright
Running: dpkg-deb -c python3-bpfcc_0.36.1-1+delphix.2026.02.27.22.53_all.deb | grep '/usr/share/doc/' | grep copyright
-rw-r--r-- root/root       193 2026-02-27 22:53 ./usr/share/doc/python3-bpfcc/copyright
PACKAGE bcc: STAGE post_build_checks COMPLETED in 1 seconds

Success: Package bcc has been built successfully.
Build products are in /export/home/delphix/linux-pkg/packages/bcc/tmp/artifacts
```

Testing BCC programs work 
```delphix@ip-10-110-223-173:~$ sudo profile-bpfcc 1
Sampling at 49 Hertz of all threads by user + kernel stack for 1 secs.
^C
    __raw_spin_unlock_irq+0x10 [kernel]
    __raw_spin_unlock_irq+0x10 [kernel]
    process_one_work+0x15d [kernel]
    worker_thread+0x2e5 [kernel]
    kthread+0xe7 [kernel]
    ret_from_fork+0x44 [kernel]
 ```


Some estat commands are still failing though that will be separately tracked/addressed with https://perforce.atlassian.net/browse/DLPX-96701
```
delphix@ip-10-110-223-173:~$ sudo estat zpl 2
In file included from /virtual/main.c:62:
In file included from /usr/src/zfs-6.14.0-1018-dx2025121319-a7d298781-aws/include/sys/spa_impl.h:42:
/usr/src/zfs-6.14.0-1018-dx2025121319-a7d298781-aws/include/sys/vdev_raidz.h:43:8: error: redefinition of 'kernel_param'
   43 | struct kernel_param {};
      |        ^
include/linux/moduleparam.h:69:8: note: previous definition is here
   69 | struct kernel_param {
      |        ^
/virtual/main.c:102:2: error: use of undeclared identifier 'zfsvfs_t'
  102 |         zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
      |         ^
/virtual/main.c:102:12: error: use of undeclared identifier 'zfsvfs'
  102 |         zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
      |                   ^
/virtual/main.c:102:23: error: incomplete definition of type 'struct znode'
  102 |         zfsvfs_t *zfsvfs = zn->z_inode.i_sb->s_fs_info;
      |                            ~~^
/usr/src/zfs-6.14.0-1018-dx2025121319-a7d298781-aws/include/sys/zfs_acl.h:205:8: note: forward declaration of 'struct znode'
  205 | struct znode;
      |        ^
/virtual/main.c:104:19: error: use of undeclared identifier 'zfsvfs'
  104 |         objset_t *z_os = zfsvfs->z_os;
      |                          ^
5 errors generated.
Traceback (most recent call last):
  File "/usr/bin/estat", line 414, in <module>
    b = BPF(text=bpf_text, cflags=cflags, debug=debug_level)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/bcc/__init__.py", line 507, in __init__
    raise Exception("Failed to compile BPF module %s" % (src_file or "<text>"))
Exception: Failed to compile BPF module <text>
```
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
