### PR TITLE
DLPX-97141 Ubuntu Security Notification for OpenSSH Vulnerabilities (USN-8222-1)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -47,7 +47,19 @@ SKIP_COPYRIGHTS_CHECK=true
 function fetch() {
 	logmust cd "$WORKDIR/artifacts"
 
-	local debs=()
+	#
+	# USN-8222-1 (DLPX-97141): backport openssh 1:9.6p1-3ubuntu13.16 to the
+	# release-track appliance. Fixes CVE-2026-35414, -35387, -35386, -35388,
+	# -35385. Fetched from Ubuntu's archive
+	# (http://security.ubuntu.com/ubuntu/pool/main/o/openssh/), which is the
+	# upstream the Delphix mirror was relaying when dlpx-develop build #4112
+	# absorbed the fix.
+	#
+	local debs=(
+		"openssh-client_9.6p1-3ubuntu13.16_amd64.deb c773e3d5b2a12d5f2ccdb1a86701975c9c089479ab0e71145057ce7defde7f47"
+		"openssh-server_9.6p1-3ubuntu13.16_amd64.deb 5ccbc09a1bd9b84272ae8f90e46c99d3089e459eb2da4b052eb91c37f8273165"
+		"openssh-sftp-server_9.6p1-3ubuntu13.16_amd64.deb 20910ca46a77764be4b1b03f5f2b41ecee78a892e18f16e150265439211321ef"
+	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"
 


### PR DESCRIPTION
## Summary

Backports the Ubuntu USN-8222-1 openssh patch (`1:9.6p1-3ubuntu13.16`) to the release-track appliance via the `misc-debs` extension point. Fixes [DLPX-97141](https://perforce.atlassian.net/browse/DLPX-97141) — Qualys QID 6032777 (CVE-2026-35414, -35387, -35386, -35388, -35385).

- `packages/misc-debs/config.sh`: three sha256-pinned `debs=()` entries (one per `.deb`) under an inline comment block naming the USN, Jira, CVEs, and the Ubuntu archive source.
- `.deb`s already live at `https://artifactory.delphix.com/artifactory/linux-pkg/misc-debs/` (`openssh-{client,server,sftp-server}_9.6p1-3ubuntu13.16_amd64.deb`).

## Coordination

This change is the Phase 2 implementation of OpenSpec change [`openssh-usn-8222-1`](https://github.com/delphix/cd-aidlc/tree/main/openspec/changes/openssh-usn-8222-1) in `delphix/cd-aidlc`. Spec PR: [delphix/cd-aidlc#41](https://github.com/delphix/cd-aidlc/pull/41) (merged). Impl branch in cd-aidlc: [`projects/openspec/openssh-usn-8222-1-rollup`](https://github.com/delphix/cd-aidlc/tree/projects/openspec/openssh-usn-8222-1-rollup).

Capture of sha256s, artifactory PUT evidence, and Phase 2 build/test results lives at [`openspec/changes/openssh-usn-8222-1/verification.md#phase-2--linux-pkg`](https://github.com/delphix/cd-aidlc/blob/projects/openspec/openssh-usn-8222-1-rollup/openspec/changes/openssh-usn-8222-1/verification.md#phase-2--linux-pkg).

## Test plan

- [ ] PR check passes (`make shellcheck` + `make shfmtcheck` — both clean locally on this branch).
- [ ] misc-debs Jenkins pre-push job indexes this branch and the `fetch()` step resolves all three artifactory URLs with matching sha256s.
- [ ] `git-ab-pre-push` from this worktree builds an appliance image with the three `.16` `.deb`s replacing Ubuntu's `.15`, and `pre-checkin` regression suite passes (sshd is the transport for the entire suite, so any regression surfaces).
- [ ] On a VM provisioned from the resulting image: `dpkg-query -W openssh-{client,server,sftp-server}` reports `1:9.6p1-3ubuntu13.16` for all three; `whoami` over ssh exits 0; sftp round-trip preserves sha256.
- [ ] Post-merge: Qualys re-scan of a freshly-provisioned 2026.3.x appliance reports zero hits for QID 6032777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)