### PR TITLE
DLPX-97147 Ubuntu Security Notification for kmod update Vulnerability (USN-8226-1)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -55,10 +55,21 @@ function fetch() {
 	# upstream the Delphix mirror was relaying when dlpx-develop build #4112
 	# absorbed the fix.
 	#
+	# USN-8226-1 (DLPX-97147): backport kmod 31+20240202-2ubuntu7.2 to the
+	# release-track appliance. Pairs with the delphix-platform release-branch
+	# fix in DLPX-97204 (that PR drops disable-algif_aead.conf from
+	# delphix-platform-aws so kmod can own the conffile), resolving the
+	# 2026.3 -> 2026.4 upgrade dpkg file-overwrite conflict. Fetched from
+	# Ubuntu's archive (http://security.ubuntu.com/ubuntu/pool/main/k/kmod/),
+	# the upstream the Delphix mirror was relaying when dlpx-develop
+	# post-push #4117 absorbed the fix.
+	#
 	local debs=(
 		"openssh-client_9.6p1-3ubuntu13.16_amd64.deb c773e3d5b2a12d5f2ccdb1a86701975c9c089479ab0e71145057ce7defde7f47"
 		"openssh-server_9.6p1-3ubuntu13.16_amd64.deb 5ccbc09a1bd9b84272ae8f90e46c99d3089e459eb2da4b052eb91c37f8273165"
 		"openssh-sftp-server_9.6p1-3ubuntu13.16_amd64.deb 20910ca46a77764be4b1b03f5f2b41ecee78a892e18f16e150265439211321ef"
+		"kmod_31+20240202-2ubuntu7.2_amd64.deb 687693dfad23c96570d96a1c7cc1b8709d31a93f82ac765a11b2bd9130f1dfae"
+		"libkmod2_31+20240202-2ubuntu7.2_amd64.deb a9cbdc424bc0a5c8af3d6445488a48de76df5ff4d76b7dab8aaf88f712358bbc"
 	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"


### PR DESCRIPTION
## Summary

USN-8226-1 ships `kmod` and `libkmod2` at `31+20240202-2ubuntu7.2`. dlpx-develop already absorbed the fix (verified on `psurya-dev-usn8226`, 2026.4.0.0 / post-push #4117); dlpx-release ships the older `31+20240202-2ubuntu7.1` (verified on `psurya-rel-usn8226`, 2026.3.0.0 / post-push #366). Jira: [DLPX-97147](https://perforce.atlassian.net/browse/DLPX-97147).

This PR backports the kmod and libkmod2 `.deb`s to the release-track appliance via `packages/misc-debs/config.sh`'s `debs=()`, using the same mechanism the openssh USN-8222-1 backport (#391) introduced.

## Paired with

This PR is one half of a coordinated two-repo fix (OpenSpec change `kmod-usn-8226-1` in delphix/cd-aidlc#47):

1. **delphix/delphix-platform#561 (release branch)** — drops `/etc/modprobe.d/disable-algif_aead.conf` from `delphix-platform-aws` so kmod can own the conffile. Lands **first**.
2. **THIS PR** — adds kmod + libkmod2 to misc-debs. Lands **after** #561 (its CI gates on #561 being on the release branch, otherwise the appliance build hits a dpkg file-overwrite conflict).

The pair resolves both DLPX-97147 (USN security parity) and [DLPX-97204](https://perforce.atlassian.net/browse/DLPX-97204) (the 2026.3 → 2026.4 upgrade conflict that surfaced on 2026-05-06).

## What changed

- Two new entries in `packages/misc-debs/config.sh::debs=()`, each as `"<filename> <sha256>"`:
  - `kmod_31+20240202-2ubuntu7.2_amd64.deb` sha256 `687693dfad23c96570d96a1c7cc1b8709d31a93f82ac765a11b2bd9130f1dfae`
  - `libkmod2_31+20240202-2ubuntu7.2_amd64.deb` sha256 `a9cbdc424bc0a5c8af3d6445488a48de76df5ff4d76b7dab8aaf88f712358bbc`
- Comment block above the entries names USN-8226-1, DLPX-97147, DLPX-97204, and the Ubuntu archive source — matching the file's `IMPORTANT NOTE` convention.

Note: `libkmod-dev` is NOT in the array — it is uploaded to artifactory (append-only bucket) but not installed on the appliance per VM-side scan.

## Validation

- `make shellcheck` exit 0 (no findings).
- `shfmt -d packages/misc-debs/config.sh` exit 0.
- Each `.deb` pulled from Ubuntu's archive on 2026-05-12; `dpkg-deb -f` confirms `Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>` + exact target version. Round-trip read-back from artifactory matches local sha256 byte-for-byte.

## Test plan

- [ ] `appliance-build-orchestrator-pre-push` **[#14010](https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14010/)** (in flight, kicked off 2026-05-12) — running with `-b "misc-debs delphix-platform" --extra-repo <delphix-platform-feature-branch>`. Four stages: Build Packages → Build Appliance → Import to DCenter (AMI in `dlpx-psurya-release`) → Run Tests, including `test_upgrade_linux_system` which is the canonical DLPX-97204 pass gate.
- [ ] Post-build AMI smoke: `dpkg-query -W kmod libkmod2` ≥ `31+20240202-2ubuntu7.2`; `dpkg-query -S /etc/modprobe.d/disable-algif_aead.conf` → `kmod: ...`.
- [ ] Manual Jenkins commit-status check posted to this PR's HEAD sha pointing at the #14010 result once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)