### PR TITLE
TOOL-30021 Enable sdb upstream tracking + bootstrap upstreams branch on first sync

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -788,7 +788,12 @@ function git_fetch_helper() {
 		label='[token passed]'
 	fi
 	echo "Running: $label git fetch $orig_url $*"
-	git fetch "$git_url" "$@" || die "git fetch failed"
+	#
+	# Don't die here; logmust callers still fail-hard via logmust's own
+	# error handling, while non-logmust callers (e.g. fetch_repo_from_git's
+	# upstream-branch bootstrap fallback) can react to the failure.
+	#
+	git fetch "$git_url" "$@"
 }
 
 #
@@ -827,8 +832,30 @@ function fetch_repo_from_git() {
 	if [[ "$DO_UPDATE_PACKAGE" == "true" ]]; then
 		logmust git_fetch_helper "$PACKAGE_GIT_URL" --no-tags \
 			"+$PACKAGE_GIT_BRANCH:repo-HEAD"
-		logmust git_fetch_helper "$PACKAGE_GIT_URL" --no-tags \
-			"+upstreams/$DEFAULT_GIT_BRANCH:upstream-HEAD"
+		#
+		# Try to fetch the upstream-tracking branch from the package's
+		# own repository. If it doesn't exist yet -- first time the
+		# package is being synced -- bootstrap upstream-HEAD directly
+		# from the third-party upstream specified by UPSTREAM_GIT_URL /
+		# UPSTREAM_GIT_BRANCH, and mark upstream-updated so
+		# sync-with-upstream.sh pushes upstream-HEAD back to origin,
+		# creating the upstreams/<branch> branch in the process.
+		#
+		if git_fetch_helper "$PACKAGE_GIT_URL" --no-tags \
+			"+upstreams/$DEFAULT_GIT_BRANCH:upstream-HEAD"; then
+			:
+		elif [[ -n "$UPSTREAM_GIT_URL" && -n "$UPSTREAM_GIT_BRANCH" ]]; then
+			echo "NOTE: upstreams/$DEFAULT_GIT_BRANCH does not exist" \
+				"on $PACKAGE_GIT_URL; bootstrapping upstream-HEAD" \
+				"from $UPSTREAM_GIT_URL ($UPSTREAM_GIT_BRANCH)."
+			logmust git_fetch_helper "$UPSTREAM_GIT_URL" --no-tags \
+				"+$UPSTREAM_GIT_BRANCH:upstream-HEAD"
+			logmust touch "$WORKDIR/upstream-updated"
+		else
+			die "Failed to fetch upstreams/$DEFAULT_GIT_BRANCH from" \
+				"$PACKAGE_GIT_URL and UPSTREAM_GIT_URL/" \
+				"UPSTREAM_GIT_BRANCH are not set to bootstrap from."
+		fi
 		logmust git show-ref repo-HEAD
 		logmust git show-ref upstream-HEAD
 	else

--- a/packages/sdb/config.sh
+++ b/packages/sdb/config.sh
@@ -18,10 +18,27 @@
 # shellcheck disable=SC2034
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/sdb.git"
 
+UPSTREAM_GIT_URL="https://github.com/sdimitro/sdb.git"
+UPSTREAM_GIT_BRANCH="develop"
+
 function prepare() {
 	logmust install_build_deps_from_control_file
 }
 
 function build() {
+	local scm_version
+	scm_version=$(cd "$WORKDIR/repo" && python3 -m setuptools_scm 2>/dev/null) ||
+		die "setuptools_scm version derivation failed"
+	#
+	# pyproject.toml sets local_scheme="no-local-version", so the value
+	# is debian-version-safe. Pass it through as-is; linux-pkg's
+	# set_changelog appends "-1delphix.<ts>" since PACKAGE_VERSION has
+	# no "-", producing e.g. "0.6.0-1delphix.<ts>".
+	#
+	export PACKAGE_VERSION="${scm_version}"
 	logmust dpkg_buildpackage_default
+}
+
+function update_upstream() {
+	logmust update_upstream_from_git
 }


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

[Spec 0003 Phase 2](https://github.com/delphix/cd-aidlc/blob/main/specs/0003/README.md) onboards `sdb` as an upstream-tracked package against `sdimitro/sdb`. Phase 1 (`delphix/sdb#360`) merged 2026-05-06 and landed the bootstrap merge from `sdimitro/develop` plus the `dh-virtualenv` overlay. The linux-pkg side is wiring `update_upstream()` up against `sdimitro/sdb`'s `develop`, and having `build()` derive `PACKAGE_VERSION` from `setuptools_scm` so the `.deb`'s metadata version follows upstream sdb tags automatically.

</details>

<details open>
<summary><h2> Problem </h2></summary>

The first check-updates run against the new sdb recipe fails before reaching `update_upstream` at all, e.g.

```
Running: [token passed] git fetch https://github.com/delphix/sdb.git --no-tags +upstreams/develop:upstream-HEAD
fatal: couldn't find remote ref upstreams/develop
Error: git fetch failed
```

`fetch_repo_from_git` requires `upstreams/$DEFAULT_GIT_BRANCH` to already exist on the package repo's origin before the update_upstream stage even runs; `update_upstream_from_git` only fast-forwards an existing local `upstream-HEAD`, it doesn't create it. The linux-pkg README's onboarding section (around line 740) says you're supposed to push that branch by hand at repo-creation time, but the branch protection on `delphix/sdb` restricts pushes to `upstreams/*` to `delphix-devops-bot` only, so a human spec author can't do it themselves; the bot only pushes during the normal sync flow, which can't run because the branch doesn't exist. Chicken-and-egg.

The same gap applies to every future upstream-tracked package that gets onboarded.

</details>

<details open>
<summary><h2> Solution </h2></summary>

The solution is to bootstrap `upstream-HEAD` from `UPSTREAM_GIT_URL` / `UPSTREAM_GIT_BRANCH` directly when the package repo's `upstreams/<branch>` is missing, and `touch $WORKDIR/upstream-updated` so `sync-with-upstream.sh` pushes the bootstrapped ref back via the bot creds it already uses at the push step. `git push` of a non-existent remote branch creates it, so the first sync run becomes the moment `upstreams/<branch>` is born on origin; subsequent runs are no different from the existing fast-forward path.

To make the conditional fetch possible, `git_fetch_helper`'s internal `|| die` is dropped. The four existing callers all use `logmust`, which handles failure identically, so the new fallback caller can branch on the exit code without losing the fail-hard behavior elsewhere.

Two files change: the bootstrap fallback in `lib/common.sh`, and the sdb recipe at `packages/sdb/config.sh`, which surfaces the gap and is needed to verify the fallback end-to-end against a real upstream-tracked recipe.

</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Jenkins check-updates [#1148](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/check-updates/job/main/1148/) on this branch with `PACKAGES=sdb`, `UPDATE_PACKAGES=false`. The bootstrap path hits, `upstream-HEAD` populates from `sdimitro/sdb` `develop`, and "Package sdb has updates available" reports cleanly, e.g.

```
fatal: couldn't find remote ref upstreams/develop
NOTE: upstreams/develop does not exist on https://github.com/delphix/sdb.git; bootstrapping upstream-HEAD from https://github.com/sdimitro/sdb.git (develop).
Running: [token passed] git fetch https://github.com/sdimitro/sdb.git --no-tags +develop:upstream-HEAD
 * [new branch]      develop    -> upstream-HEAD
Running: touch .../upstream-updated
Success: Package sdb has updates available.
```

For contrast, [#1147](https://ops-jenkins.eng-tools-prd.aws.delphixcloud.com/job/linux-pkg/job/develop/job/check-updates/job/main/1147/) at the prior branch tip confirms the original failure mode.

Post-merge verification (out of scope here):

- Seed job picks up sdb's `update_upstream()` definition and auto-generates `update-package/sdb`.
- First nightly cron run, after [delphix/devops-gate#4438](https://github.com/delphix/devops-gate/pull/4438) also lands, exercises the real push of `upstreams/develop` to `delphix/sdb` and merges upstream into `develop`. That also satisfies the long-deferred Phase 1 AC #2 as a side-effect.
- `build-package/sdb/pre-push` to verify the `.deb`'s `Version:` field derives from `setuptools_scm` (Phase 2 AC #11).

</details>

Spec context: [delphix/cd-aidlc#62](https://github.com/delphix/cd-aidlc/pull/62). JIRA: [TOOL-30021](https://perforce.atlassian.net/browse/TOOL-30021).
