### PR TITLE
DLPX-97390 Embed connector version in Windows installer artifact filename

### DIFF
--- a/packages/windows-connector/config.sh
+++ b/packages/windows-connector/config.sh
@@ -32,4 +32,15 @@ function build() {
 	logmust cd "$INSTALLER_DIR"
 	logmust sudo ../../gradlew createDebPackage
 	logmust sudo mv ./build/distributions/*deb "$WORKDIR/artifacts/"
+	#
+	# Publish the standalone Windows connector installer with the connector version in its
+	# filename so downstream publishing can nest it under a version directory.
+	# The version is read from build.gradle (connectorVersion property). See DLPX-17800.
+	#
+	logmust test -f "$INSTALLER_DIR/build.gradle"
+	connector_version=$(grep -oP "connectorVersion\s*=\s*'\K[^']+" \
+		"$INSTALLER_DIR/build.gradle")
+	logmust test -n "$connector_version"
+	logmust sudo cp ./build/DelphixConnector/DelphixConnectorInstaller.exe \
+		"$WORKDIR/artifacts/DelphixConnectorInstaller-${connector_version}.exe"
 }


### PR DESCRIPTION
<details open>
<summary><h2> Problem </h2></summary>

The linux-pkg windows-connector build produces a flat `DelphixConnectorInstaller.exe` with no version information. Downstream pipeline stages (devops-gate stage0) have no way to determine which connector version the artifact corresponds to, making it impossible to publish under a version-namespaced directory.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Read `connectorVersion` from the checked-out `build.gradle` and copy the installer as `DelphixConnectorInstaller-<ver>.exe` instead of the flat name. This allows devops-gate stage0 to discover the version from the filename and publish under `windows-connector/<ver>/DelphixConnectorInstaller.exe`.

Companion change: [devops-gate DLPX-97389](https://github.com/delphix/devops-gate/pull/4456) consumes the versioned filename and creates the version directory in the per-build S3 bucket and on the download center.
</details>

<details>
<summary><h2> Testing Done </h2></summary>

Pre-push appliance build verified — `windows-connector/2.1.0.0/DelphixConnectorInstaller.exe` present in the per-build S3 bucket alongside `SHA256SUMS` and `MD5SUMS`.
</details>