### PR TITLE
DLPX-97018 grub2 package doesn't need to be rebuilt

### DIFF
--- a/packages/grub2/config.sh
+++ b/packages/grub2/config.sh
@@ -16,7 +16,7 @@
 #
 # shellcheck disable=SC2034
 
-DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/grub2"
+DEFAULT_PACKAGE_GIT_URL=none
 SKIP_COPYRIGHTS_CHECK=true
 
 URI="s3://release-de-images/internal-artifacts/2025.3.0.1/1.0.53/input-artifacts/combined-packages/packages/grub2"


### PR DESCRIPTION
We're no longer updating grub from upstream, so, setting `DEFAULT_PACKAGE_GIT_URL` to `none` prevents some unnecessary sync work that is no longer relevant.