### PR TITLE
HM-5952 Add mount-s3 to misc-debs for Hyperscale S3 FUSE driver

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -47,7 +47,13 @@ SKIP_COPYRIGHTS_CHECK=true
 function fetch() {
 	logmust cd "$WORKDIR/artifacts"
 
-	local debs=()
+	local debs=(
+		# mount-s3 (Mountpoint for Amazon S3) v1.22.3 — FUSE driver for mounting S3 buckets.
+		# mount-s3 has no apt repository; fetched from AWS S3 and uploaded to Artifactory.
+		# Source: https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
+		# Required by HM-5952 (Hyperscale Snowflake connector S3 staging mounts). DLPXECO-13872.
+		"mount-s3_1.22.3_amd64.deb 259a793b1233258b35ce5ce902df177393542fd76dd2a606f07e800e28591df6"
+	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"
 


### PR DESCRIPTION
## Summary
- Adds `mount-s3_1.22.3_amd64.deb` to the `misc-debs` package's `debs` array in `packages/misc-debs/config.sh`
- mount-s3 (Mountpoint for Amazon S3) has no apt repository — Amazon distributes it only as a direct .deb download from S3, so it fits the misc-debs pattern

## Pre-requisite (manual step before this PR can build)
Upload the deb to Artifactory:
- **Path:** `linux-pkg/misc-debs/mount-s3_1.22.3_amd64.deb`
- **SHA256:** `259a793b1233258b35ce5ce902df177393542fd76dd2a606f07e800e28591df6`
- **Source:** https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb

cc @prakashsurya — following your suggestion on appliance-build#872 to use misc-debs.

## Context
Part of HM-5952 (bundle mount-s3 and blobfuse2 FUSE drivers into the Delphix closed appliance image for the Hyperscale Snowflake connector). OSRB tracking: DLPXECO-13872.

Three PRs total:
1. devops-gate PR #4503 — vendor blobfuse2 PPA into mirror
2. **This PR** — add mount-s3 to misc-debs
3. appliance-build PR #872 — Ansible tasks to install both drivers (exclusion to be reverted once both packages are in mirror)

## Test plan
- [ ] Upload `mount-s3_1.22.3_amd64.deb` to Artifactory at the path above
- [ ] Run `./buildpkg.sh misc-debs` on a noble build VM and confirm mount-s3 deb appears in artifacts
- [ ] Verify SHA256 matches after fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)