### PR TITLE
DLPX-97858 Ubuntu Security Notification for Gzip Vulnerabilities (USN-8512-1)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -53,6 +53,12 @@ function fetch() {
 		# Source: https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
 		# Required by HM-5952 (Hyperscale Snowflake connector S3 staging mounts). DLPXECO-13872.
 		"mount-s3_1.22.3_amd64.deb 259a793b1233258b35ce5ce902df177393542fd76dd2a606f07e800e28591df6"
+		#
+		# gzip 1.12-1ubuntu3.2 - Ubuntu USN-8512-1 (Gzip vulnerability).
+		# Pin the fixed gzip binary into the release appliance to remediate
+		#   CVE-2026-41992 (DLPX-97858).
+		# Fetched from the Ubuntu 24.04 LTS (noble) noble-security/noble-updates archive.
+		"gzip_1.12-1ubuntu3.2_amd64.deb 4067522fbffe22672e4cf683bfc32e4a304bc872cf76f10049ab36d1a9eedb91"
 	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"


### PR DESCRIPTION
## Summary

Backports the Ubuntu **USN-8512-1** `gzip` security update (`1.12-1ubuntu3.2`) to the release-track appliance via the `misc-debs` extension point. The `release` build (2026.4.0.0) installs `1.12-1ubuntu3.1`, which is still vulnerable.

Remediates:
- [DLPX-97858](https://perforce.atlassian.net/browse/DLPX-97858) — CVE-2026-41992 (CVSS 7.5)

Changes:
- `packages/misc-debs/config.sh`: one sha256-pinned `debs=()` entry under a comment block naming the USN, Jira ticket, CVE, and the Ubuntu archive source.
- `.deb` uploaded to `http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs/`:
  - `gzip_1.12-1ubuntu3.2_amd64.deb`

Fetched from the Ubuntu 24.04 LTS (noble) `noble-security`/`noble-updates` archive.

## Test plan

- [ ] PR check passes (`make shellcheck` + `make shfmtcheck` — both clean locally on this branch).
- [ ] misc-debs Jenkins pre-push job resolves the artifactory URL with matching sha256.
- [ ] `git-ab-pre-push` builds an appliance image with `1.12-1ubuntu3.2` replacing `3.1`; `pre-checkin` regression passes.
- [ ] On a VM from the resulting image: `dpkg-query -W gzip` reports `1.12-1ubuntu3.2`; `gzip`/`gunzip` round-trip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing Done

### ab-pre-push build #14507: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14507/
- Tested: `linux-pkg@a74eb13` (against `release`); additional package built: `misc-debs`
- Status: running — result not yet available; re-run recording in completed mode once the build finishes.
