### PR TITLE
DLPX-97846 Ubuntu Security Notification for Vim Vulnerabilities (USN-8500-1)

### DIFF
--- a/packages/misc-debs/config.sh
+++ b/packages/misc-debs/config.sh
@@ -53,6 +53,15 @@ function fetch() {
 		# Source: https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
 		# Required by HM-5952 (Hyperscale Snowflake connector S3 staging mounts). DLPXECO-13872.
 		"mount-s3_1.22.3_amd64.deb 259a793b1233258b35ce5ce902df177393542fd76dd2a606f07e800e28591df6"
+		#
+		# vim 2:9.1.0016-1ubuntu7.17 - Ubuntu USN-8500-1 (Vim vulnerabilities).
+		# Pin the fixed vim binaries into the release appliance to remediate:
+		#   CVE-2026-57455 (DLPX-97851), CVE-2026-55693 (DLPX-97850),
+		#   CVE-2026-57456 (DLPX-97847), CVE-2026-55895 (DLPX-97846).
+		# Fetched from the Ubuntu 24.04 LTS (noble) noble-security/noble-updates archive.
+		"vim_9.1.0016-1ubuntu7.17_amd64.deb 3abc1c2a22f5a542d8c6cf1b85085783b6136c0467d7c7601aee9fbd4d041713"
+		"vim-common_9.1.0016-1ubuntu7.17_all.deb 3d5eaa2b23196b573d020804a62eff2b4d667f43b8e4b324a0b91a4b76d12636"
+		"vim-runtime_9.1.0016-1ubuntu7.17_all.deb 9fe33de15cf9e531e5f34a02c999abd8e7cfdf6543beb5665fa0325eb03922f4"
 	)
 
 	local url="http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs"


### PR DESCRIPTION
## Summary

Backports the Ubuntu **USN-8500-1** `vim` security update (`2:9.1.0016-1ubuntu7.17`) to the release-track appliance via the `misc-debs` extension point. The `release` build (2026.4.0.0) installs `2:9.1.0016-1ubuntu7.16`, which is still vulnerable to these CVEs.

Remediates:
- [DLPX-97851](https://perforce.atlassian.net/browse/DLPX-97851) — CVE-2026-57455 (CVSS 7.8)
- [DLPX-97850](https://perforce.atlassian.net/browse/DLPX-97850) — CVE-2026-55693 (CVSS 7.8)
- [DLPX-97847](https://perforce.atlassian.net/browse/DLPX-97847) — CVE-2026-57456 (CVSS 7.8)
- [DLPX-97846](https://perforce.atlassian.net/browse/DLPX-97846) — CVE-2026-55895 (CVSS 7.8)

Changes:
- `packages/misc-debs/config.sh`: three sha256-pinned `debs=()` entries — the `vim` binaries the appliance installs — under a comment block naming the USN, Jira tickets, CVEs, and the Ubuntu archive source.
- `.deb`s uploaded to `http://artifactory.delphix.com/artifactory/linux-pkg/misc-debs/` (epoch stripped from filenames per Debian pool convention):
  - `vim_9.1.0016-1ubuntu7.17_amd64.deb`
  - `vim-common_9.1.0016-1ubuntu7.17_all.deb`
  - `vim-runtime_9.1.0016-1ubuntu7.17_all.deb`

Fetched from the Ubuntu 24.04 LTS (noble) `noble-security`/`noble-updates` archive.

## Test plan

- [ ] PR check passes (`make shellcheck` + `make shfmtcheck` — both clean locally on this branch).
- [ ] misc-debs Jenkins pre-push job resolves all three artifactory URLs with matching sha256s.
- [ ] `git-ab-pre-push` builds an appliance image with `...ubuntu7.17` replacing `7.16`; `pre-checkin` regression passes.
- [ ] On a VM from the resulting image: `dpkg-query -W vim vim-common vim-runtime` reports `2:9.1.0016-1ubuntu7.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Testing Done

### ab-pre-push build #14508: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14508/
- Tested: `linux-pkg@ef02e7b` (against `release`); additional package built: `misc-debs`
- Status: running — result not yet available; re-run recording in completed mode once the build finishes.
