### PR TITLE
DLPX-97954 Add support for local maven build for password-vault-manager

### DIFF
--- a/packages/virtualization/config.sh
+++ b/packages/virtualization/config.sh
@@ -32,12 +32,46 @@ function prepare() {
 		"$DEPDIR"/host-jdks/*.deb
 }
 
+#
+# Optional validation hook: when PVM_GIT_URL/PVM_GIT_BRANCH are both set, build
+# password_vault_manager from that ref, publish it to the local Maven repo, and
+# point the appliance build's ivy resolution at it (see the
+# third.party.local.maven.root property in dlpx-app-gate's
+# appliance/ant/ivysettings.xml) instead of whatever version is pinned in
+# appliance/gradle.properties. No-op (and no behavior change) when unset.
+#
+function build_local_password_vault_manager_jar() {
+	logmust mkdir "$WORKDIR/pvm"
+	logmust mkdir "$WORKDIR/pvm/repo"
+	logmust cd "$WORKDIR/pvm/repo"
+	logmust git init
+	logmust git_fetch_helper "$PVM_GIT_URL" --no-tags "+$PVM_GIT_BRANCH:pvm-HEAD" --depth=1
+	logmust git checkout pvm-HEAD
+
+	#
+	# Skip test/dxosTest here -- they already ran as part of
+	# password-vault-manager-precommit-tests earlier in the pvm_precheckin flow. This step only
+	# needs to produce and publish the jar.
+	#
+	logmust ./gradlew --no-daemon --stacktrace -x test -x dxosTest publishToMavenLocal
+
+	PVM_LOCAL_VERSION="$(grep '^version=' gradle.properties | cut -d= -f2)"
+	export PVM_LOCAL_VERSION
+	echo_bold "Built password_vault_manager version ${PVM_LOCAL_VERSION} from" \
+		"${PVM_GIT_URL} (${PVM_GIT_BRANCH}) and published it to the local Maven repo" \
+		"(~/.m2/repository)."
+}
+
 function build() {
 	export JAVA_HOME
 	JAVA_HOME="/usr/lib/jvm/java-17-openjdk-amd64/"
 
 	export LANG
 	LANG=en_US.UTF-8
+
+	if [[ -n "$PVM_GIT_URL" && -n "$PVM_GIT_BRANCH" ]]; then
+		logmust build_local_password_vault_manager_jar
+	fi
 
 	logmust cd "$WORKDIR/repo"
 
@@ -71,6 +105,18 @@ function build() {
 
 	if [[ -n "$DELPHIX_RELEASE_VERSION" ]]; then
 		args+=("-DhotfixGenDlpxVersion=$DELPHIX_RELEASE_VERSION")
+	fi
+
+	if [[ -n "$PVM_LOCAL_VERSION" ]]; then
+		args+=("-Dthird.party.local.maven.root=file://$HOME/.m2/repository")
+		export ORG_GRADLE_PROJECT_passwordVaultManagerVer="$PVM_LOCAL_VERSION"
+		echo_bold "Using LOCALLY-BUILT password_vault_manager ${PVM_LOCAL_VERSION} for this build" \
+			"-- NOT fetched from Artifactory. ivy will resolve" \
+			"com.delphix.vault:password-vault-manager:${PVM_LOCAL_VERSION} from the local Maven repo" \
+			"(~/.m2/repository) instead."
+	else
+		echo "PVM_GIT_URL/PVM_GIT_BRANCH not set: password-vault-manager will be fetched from" \
+			"Artifactory as usual, using the version pinned in appliance/gradle.properties."
 	fi
 
 	logmust ant "${args[@]}" all-secrets package


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

Testing an in-progress `password-vault-manager` (PVM) change against the appliance build
currently requires that change to already be published to Artifactory, since
`packages/virtualization/config.sh` always resolves PVM at the version pinned in
`dlpx-app-gate`'s `appliance/gradle.properties`. Anyone validating a cross-repo change
between `dlpx-app-gate` and `password-vault-manager` has to wait for a PVM publish (or
manually hack the pinned version) before they can even build the appliance against it,
which adds unnecessary iteration latency to development and pre-checkin testing.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add an opt-in hook to `packages/virtualization/config.sh`, gated behind two new
environment variables, `PVM_GIT_URL` and `PVM_GIT_BRANCH`:

- When both are set, `build()` shallow-clones that ref of `password-vault-manager`, runs
  `./gradlew publishToMavenLocal` (skipping `test`/`dxosTest`, since those already ran as
  part of the `password-vault-manager-precommit-tests` step earlier in the
  `pvm_precheckin` flow) to publish the jar into `~/.m2/repository`, and passes
  `-Dthird.party.local.maven.root=file://$HOME/.m2/repository` and
  `ORG_GRADLE_PROJECT_passwordVaultManagerVer=<local version>` to the `ant` build, so ivy
  resolves the locally-built jar instead of the Artifactory one.
- When either variable is unset (the default, unchanged path), PVM continues to be
  fetched from Artifactory using the version pinned in `appliance/gradle.properties` --
  no behavior change for existing builds.

This lets a developer point a virtualization build at an unpublished PVM branch for
local validation without touching the pinned version or waiting on a publish.
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

| # | Test | How | Status |
|---|------|-----|--------|
| 1 | Run `integration-tests/password-vault-manager-precommit-tests/pre-push` (unit + dxos tests) | Downstream Jenkins job, triggered with `propagate: false` | Implemented in [PR #4604](https://github.com/delphix/devops-gate/pull/4604) (`834231db1`) |

</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
