### PR TITLE
DLPX-98296 linux-kernel-generic pre-push build fails: ipu7-drivers DKMS module missing do_ipu7=false disable flag

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -140,6 +140,7 @@ function kernel_build() {
 		"uefi_signed=false"
 		"do_zfs=false"
 		"do_ipu6=false"
+		"do_ipu7=false"
 		"do_iwlwifi=false"
 		"do_v4l2loopback=false"
 		"do_usbio=false"


### PR DESCRIPTION
<!--
<details open>
<summary><h2> Background </h2></summary>

Provide a clear description of the high-level effort with which this
pull request is associated. Recall that while anyone in the organization
can see this pull request, not everyone necessarily has the same context
as you. If applicable, link to design documents or high-level tracking
epics here.
</details>
-->

<details open>
<summary><h2> Problem </h2></summary>

The `linux-kernel-generic` pre-push appliance build fails to compile the
`ipu7-drivers` DKMS module (Intel IPU7 camera driver, pulled from the Ubuntu
archive rather than built from our own kernel source) after rebasing onto
`Ubuntu-hwe-7.0-7.0.0-28.28_24.04.1`:

```
drivers/media/i2c/ov02c10.c: In function 'ov02c10_set_format':
drivers/media/i2c/ov02c10.c:1328:18: error: implicit declaration of function 'v4l2_subdev_state_get_format'
drivers/media/i2c/ov02c10.c: In function 'ov02c10_probe':
drivers/media/i2c/ov02c10.c:1675:20: error: 'struct v4l2_subdev' has no member named 'entity'
cc1: some warnings being treated as errors
Error: failed command 'fakeroot debian/rules binary ... flavours=generic abinum=28-dx2026080400-e92af378a'
```

(Jenkins: `linux-pkg/develop/build-package/linux-kernel-generic/pre-push` #119,
triggered from `linux-kernel-generic` PR
[#57](https://github.com/delphix/linux-kernel-generic/pull/57), DLPX-98112.)

The new upstream Linux V4L2 subdev active-state API removed the `entity`/`state`
members that `ipu7-drivers`' pinned source (a Launchpad snapshot dated
2026-02-09) still uses, so it no longer builds against the bumped kernel.
Ubuntu itself flagged this module as unsupported for the new series — it added
`off_series=true` to the `ipu7-drivers` line in `debian.hwe-7.0/dkms-versions`
(not present for the prior `debian.hwe-6.17`) — but our kernel forks' build
tooling never parses or acts on that field, so the module is still attempted
and the build fails.
</details>

<!--
<details>
<summary><h2> Evaluation </h2></summary>

If the cause of the problem is not obvious, provide a root-cause
analysis (RCA), ideally using the Five Whys iterative interrogative
technique or some other form of analytical reasoning.
</details>
-->

<details open>
<summary><h2> Solution </h2></summary>

Add `do_ipu7=false` to the `debian_rules_args` list in
`default-package-config.sh`, matching the existing `do_ipu6=false` entry for
the sibling Intel camera driver. Delphix's appliance doesn't use consumer
camera drivers on any flavour, so this module was already meant to be
excluded — it was just missing from the disable list.

An alternative would be to teach the kernel forks' `debian/rules.d` parsing to
honor the `off_series` field from `dkms-versions` generically, so future
Ubuntu-side exclusions are picked up automatically. That's a larger change
across all five kernel forks and doesn't fit a quick unblock; filed as
follow-up if we want it (not yet ticketed).
</details>


<details open>
<summary><h2> Testing Done </h2></summary>

This is a one-line config change with no automated test coverage of its own;
verification is the downstream kernel build going green.

### ab-pre-push build #14718: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14718/
- Tested: `linux-pkg@065c38acf7f7`, `linux-kernel-generic@e92af378a006`, `zfs@e62b28d4bbc4` (against `develop`)
- Status: running — re-test of the `linux-kernel-generic` pre-push build (DLPX-98112 / [PR #57](https://github.com/delphix/linux-kernel-generic/pull/57)) with this fix included as an extra repo, alongside the zfs `sockaddr_unsized` fix ([PR #2305](https://github.com/delphix/zfs/pull/2305)); re-run recording in completed mode once finished.

### Test stage final update

- `linux-kernel-generic` ([#57](https://github.com/delphix/linux-kernel-generic/pull/57)): `upgrade-testing #4622` → `blackbox-chained #9579`: UNSTABLE, but 0/97 failures (2 unrelated pre-existing skips — not implicating this fix or the rebase). Effectively a clean pass.
- `linux-kernel-aws` ([#72](https://github.com/delphix/linux-kernel-aws/pull/72)): `upgrade-testing #4621` → `blackbox-chained #9578`: FAILURE, 2/49 failures — an SSH connectivity timeout mid-upgrade (`test_upgrade_linux_system`), matching a known unresolved infra flake ([DLPXQA-53392](https://perforce.atlassian.net/browse/DLPXQA-53392), regression of [DLPXQA-43084](https://perforce.atlassian.net/browse/DLPXQA-43084)) rather than a regression tied to this linux-pkg fix. A 4th rerun (`upgrade-testing #4623`) is in progress; see linux-kernel-aws#72 for the latest.

Compile stage remains confirmed SUCCESS (`appliance-build » pre-push #7152`: SUCCESS); no code changes needed to this fix.
</details>

<!--
<details>
<summary><h2> Implementation </h2></summary>

Describe the implementation details of the solution. Generally the
reasoning behind any non-obvious code should be recorded in code
comments. However, code comments should always describe the current
state of the code; in contrast, this section may be useful to describe
the relationship between the original code and the code being proposed
in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Notes to Reviewers </h2></summary>

Provide any extra information a reviewer may need to know before
evaluating your pull request. For example, you may wish to describe
which files should be reviewed first or which files are auto-generated.
If the review tool cannot detect a file move, you may wish to link to a
patch comparing the old file and the new file.
</details>
-->

<!--
<details>
<summary><h2> Deployment Plan </h2></summary>

Describe how the code in this pull request will be deployed. Some
deployments are complicated and may require flag days between multiple
repositories or the provisioning of new infrastructure. Describing your
deployment plan allows reviewers to ensure that your work will not cause
any unnecessary interruption to end users.
</details>
-->

<!--
<details>
<summary><h2> Future Work </h2></summary>

Provide a description of any possible follow-up work that is explicitly
not being done in this pull request.
</details>
-->

<!--
<details>
<summary><h2> Bonus </h2></summary>

Provide a description of any extra problems you have solved in this pull
request.
</details>
-->
