### PR TITLE
[EXPERIMENT] windows-connector: build on-demand via Artifactory cache

### DIFF
--- a/packages/windows-connector/config.sh
+++ b/packages/windows-connector/config.sh
@@ -29,8 +29,11 @@ function prepare() {
 # windows-connector is only rebuilt when its version (project.ext.connectorVersion
 # in appliance/host/windows/build.gradle) is bumped. If that version has already
 # been built and uploaded to Artifactory, we just download the existing installer
-# instead of rebuilding. Uploading a newly built installer back to Artifactory is
-# a manual step (not done here) - see the message printed on a fresh build below.
+# instead of rebuilding. Otherwise we build it and upload the result to Artifactory
+# so future builds of the same version can reuse it. The upload uses the BLACKBOX_USERNAME/
+# BLACKBOX_PASSWORD credential exposed by the linux_pkg_build_package.groovy pipeline
+# (devops-gate) - the same 'blackbox' credential already used to publish DCT's Artifactory
+# artifacts in api_gw_services_build_publish_post_push.groovy.
 #
 function build() {
 	CONNECTOR_DIR="${WORKDIR}/repo/appliance/server/connector"
@@ -39,7 +42,7 @@ function build() {
 	local version
 	version=$(grep "project.ext.connectorVersion" "$INSTALLER_DIR/build.gradle" |
 		sed -E "s/.*'([^']+)'.*/\1/")
-	local artifactory_dir="http://artifactory.delphix.com/artifactory/linux-pkg/windows-connector/$version"
+	local artifactory_dir="http://artifactory.delphix.com/artifactory/third-party-local/windows-connector/$version"
 	local deb_name="windows-connector_${version}_all.deb"
 
 	if wget --spider -q "$artifactory_dir/$deb_name"; then
@@ -54,12 +57,19 @@ function build() {
 		logmust sudo ../../gradlew createDebPackage
 		logmust cp ./build/distributions/*.deb "$WORKDIR/artifacts/$deb_name"
 
-		echo "Uploading $deb_name to $artifactory_dir/ (no credentials supplied - testing default permissions)"
-		local http_code
-		http_code=$(curl -s -o /dev/stderr -w "%{http_code}" -T "$WORKDIR/artifacts/$deb_name" "$artifactory_dir/$deb_name")
-		echo "Artifactory upload HTTP status: $http_code"
-		if [[ "$http_code" != 2* ]]; then
-			echo "WARNING: upload did not return a 2xx status - it likely needs credentials (see curl output above)"
+		if [[ -z "$BLACKBOX_USERNAME" || -z "$BLACKBOX_PASSWORD" ]]; then
+			echo "WARNING: BLACKBOX_USERNAME/BLACKBOX_PASSWORD not set - skipping Artifactory upload." \
+				"Upload $WORKDIR/artifacts/$deb_name to $artifactory_dir/ manually so future builds can reuse it."
+		else
+			echo "Uploading $deb_name to $artifactory_dir/"
+			local http_code
+			http_code=$(curl -s -o /dev/stderr -w "%{http_code}" \
+				-u "${BLACKBOX_USERNAME}:${BLACKBOX_PASSWORD}" \
+				-T "$WORKDIR/artifacts/$deb_name" "$artifactory_dir/$deb_name")
+			echo "Artifactory upload HTTP status: $http_code"
+			if [[ "$http_code" != 2* ]]; then
+				echo "WARNING: upload did not return a 2xx status (see curl output above)"
+			fi
 		fi
 	fi
 }

--- a/packages/windows-connector/config.sh
+++ b/packages/windows-connector/config.sh
@@ -18,18 +18,48 @@
 
 DEFAULT_PACKAGE_GIT_URL="https://github.com/delphix/dlpx-app-gate.git"
 SKIP_COPYRIGHTS_CHECK=true
+PACKAGE_GIT_BRANCH="dlpx/pr/vimleshmishra/716aac3d-399f-43c7-9b80-c373ab6f7218"
 
 function prepare() {
 	logmust install_pkgs \
 		openjdk-17-jdk-headless
 }
 
+#
+# windows-connector is only rebuilt when its version (project.ext.connectorVersion
+# in appliance/host/windows/build.gradle) is bumped. If that version has already
+# been built and uploaded to Artifactory, we just download the existing installer
+# instead of rebuilding. Uploading a newly built installer back to Artifactory is
+# a manual step (not done here) - see the message printed on a fresh build below.
+#
 function build() {
 	CONNECTOR_DIR="${WORKDIR}/repo/appliance/server/connector"
 	INSTALLER_DIR="${WORKDIR}/repo/appliance/host/windows"
-	logmust cd "$CONNECTOR_DIR"
-	logmust sudo ../../gradlew build
-	logmust cd "$INSTALLER_DIR"
-	logmust sudo ../../gradlew createDebPackage
-	logmust sudo mv ./build/distributions/*deb "$WORKDIR/artifacts/"
+
+	local version
+	version=$(grep "project.ext.connectorVersion" "$INSTALLER_DIR/build.gradle" |
+		sed -E "s/.*'([^']+)'.*/\1/")
+	local artifactory_dir="http://artifactory.delphix.com/artifactory/linux-pkg/windows-connector/$version"
+	local deb_name="windows-connector_${version}_all.deb"
+
+	if wget --spider -q "$artifactory_dir/$deb_name"; then
+		echo "windows-connector $version already built; downloading pre-built installer from Artifactory"
+		logmust cd "$WORKDIR/artifacts"
+		logmust fetch_file_from_artifactory "$artifactory_dir/$deb_name"
+	else
+		echo "windows-connector $version not found in Artifactory; building from source"
+		logmust cd "$CONNECTOR_DIR"
+		logmust sudo ../../gradlew build
+		logmust cd "$INSTALLER_DIR"
+		logmust sudo ../../gradlew createDebPackage
+		logmust cp ./build/distributions/*.deb "$WORKDIR/artifacts/$deb_name"
+
+		echo "Uploading $deb_name to $artifactory_dir/ (no credentials supplied - testing default permissions)"
+		local http_code
+		http_code=$(curl -s -o /dev/stderr -w "%{http_code}" -T "$WORKDIR/artifacts/$deb_name" "$artifactory_dir/$deb_name")
+		echo "Artifactory upload HTTP status: $http_code"
+		if [[ "$http_code" != 2* ]]; then
+			echo "WARNING: upload did not return a 2xx status - it likely needs credentials (see curl output above)"
+		fi
+	fi
 }


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

Companion to [delphix/dlpx-app-gate#4648](https://github.com/delphix/dlpx-app-gate/pull/4648), which removes the pinned `mono-devel`/`mingw-w64`/`nsis` Artifactory zips from the `windows-connector` Gradle build. That fixes builds from failing due to dependency drift, but `windows-connector` still gets rebuilt on every pipeline run even when nothing about it has changed. This PR experiments with an on-demand build model instead: only build when `connectorVersion` is bumped, otherwise reuse a previously-built installer from Artifactory.
</details>

<details open>
<summary><h2> Problem </h2></summary>

`windows-connector`'s `build()` unconditionally runs the full Gradle build (`server/connector` + `host/windows:createDebPackage`) on every invocation, regardless of whether the connector's source or version actually changed since the last build.
</details>

<details open>
<summary><h2> Solution </h2></summary>

`build()` now checks Artifactory for an existing `.deb` matching the current `project.ext.connectorVersion` (from `appliance/host/windows/build.gradle`) at `artifactory/linux-pkg/windows-connector/<version>/`:
- If found, download and reuse it instead of rebuilding.
- If not found, build as before, then attempt to upload the result back to that path so future runs can reuse it.

**This PR is a working experiment, not a finished/production-ready change** — two things in it are deliberately temporary and should not be merged as-is:
- `PACKAGE_GIT_BRANCH` is hardcoded to a specific `dlpx-app-gate` PR branch (companion PR #4648), purely so this can be tested end-to-end without needing a separate Jenkins parameter override. This pin must be removed before merge.
- The upload attempt deliberately sends **no credentials**, to empirically test whether this Artifactory path already permits anonymous writes. If it doesn't (expected), this will need a real credential — see Notes to Reviewers.
</details>

<details open>
<summary><h2> Testing Done </h2></summary>

Not yet run for real — intended to be tested by triggering the `windows-connector` **pre-push** build-package Jenkins job (safe: writes to `dev-de-images`, doesn't update the `latest` pointer) with `LINUX_PKG_GIT_BRANCH` pointed at this PR's branch. Will update this section with the actual HTTP status/result once that run happens.
</details>

<details open>
<summary><h2> Notes to Reviewers </h2></summary>

If the anonymous upload attempt fails (expected — most likely 401/403), the real fix is wiring the existing `blackbox` Jenkins credential (already used by `devops-gate`'s `linux_pkg_xray_scan.groovy` for Artifactory access) into this pipeline's `withCredentials([...])` block in `devops-gate`'s `jenkins/jobs/pipelines/linux_pkg_build_package.groovy` — a separate change in a different repo, not included here.

Do not merge this PR until: (1) the hardcoded `PACKAGE_GIT_BRANCH` pin above is removed, and (2) the upload path has real credentials (or this is redesigned to not require them here).
</details>
