### PR TITLE
TOOL-30736 always use the v2 package mirror host

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -170,18 +170,17 @@ function run_setup_if_needed() {
 #
 function resolve_mirror_urls() {
 	check_env DEFAULT_GIT_BRANCH DELPHIX_RELEASE_VERSION
-	local package_mirror_url latest_url delphix_version
+	local package_mirror_url latest_url
 	local primary_url="$DELPHIX_PACKAGE_MIRROR_MAIN"
 	local secondary_url="$DELPHIX_PACKAGE_MIRROR_SECONDARY"
 
 	if [[ -z "$primary_url" ]] || [[ -z "$secondary_url" ]]; then
-		delphix_version="$DELPHIX_RELEASE_VERSION"
-		if compare_versions "$delphix_version" eq "9999.0.0.0" ||
-			compare_versions "$delphix_version" gt "2025.3"; then
-			latest_url="http://linux-package-mirror-v2.delphix.com/"
-		else
-			latest_url="http://linux-package-mirror.delphix.com/"
-		fi
+		#
+		# Every product branch is served by the v2 (aptly-based)
+		# mirror. The older linux-package-mirror.delphix.com name is
+		# deprecated and is now just an alias for the same host.
+		#
+		latest_url="http://linux-package-mirror-v2.delphix.com/"
 
 		if is_release_branch; then
 			package_mirror_url="${latest_url}releases/${DELPHIX_RELEASE_VERSION}"


### PR DESCRIPTION
[TOOL-30736](https://perforce.atlassian.net/browse/TOOL-30736)

## Why

`resolve_mirror_urls()` chose between the two package mirror hosts by comparing `DELPHIX_RELEASE_VERSION` against a literal `9999.0.0.0`, falling back to a `gt "2025.3"` check:

```sh
if compare_versions "$delphix_version" eq "9999.0.0.0" ||
	compare_versions "$delphix_version" gt "2025.3"; then
	latest_url="http://linux-package-mirror-v2.delphix.com/"
else
	latest_url="http://linux-package-mirror.delphix.com/"
fi
```

`9999.0.0.0` is not a real Delphix version. It comes from `branch_schemas.toml` in devops-gate, which assigns it to the `os-upgrade` branch, deliberately ahead of `develop`. It was picked during the previous LTS upgrade, when the new LTS had no Delphix version assigned yet and `os-upgrade` needed to reach the new mirror host while releases off `develop` kept using the old one. Nothing in `lib/common.sh` said any of that, so the check read as arbitrary in isolation.

## What changes

The conditional is gone and the v2 host is used unconditionally. This was `compare_versions()`'s only caller, but the helper stays in place as a general utility, so it is now uncalled.

The two names are the same machine, so this is behavior-preserving on every branch, not only the ones already landing on v2:

```
$ getent hosts linux-package-mirror.delphix.com linux-package-mirror-v2.delphix.com
10.110.20.69    linux_package_mirror_v21-prod-usw2.ops.delphix.com linux-package-mirror.delphix.com
10.110.20.69    linux_package_mirror_v21-prod-usw2.ops.delphix.com linux-package-mirror-v2.delphix.com
```

Both names serve identical content; the `releases/` listings match exactly, 57 entries each. Beyond that the `eq` arm was already dead, since `develop` (2026.5.0.0) and `os-upgrade` (9999.0.0.0) both satisfy `gt "2025.3"` under `dpkg --compare-versions`.

Two things the ticket asked to confirm first:

- Nothing outside linux-pkg keys off `9999.0.0.0`. It appears only as the declared `os-upgrade` version in `branch_schemas.toml` (appliance and qa-gate schemas), plus `dlpx.version.mapping` tests and README. No comparison logic anywhere, so linux-pkg held the only sentinel check.
- Whether the `os-upgrade` entry should move to a real version no longer has any bearing here, now that the version is not read for host selection. Its remaining job is sorting ahead of `develop` in the version mapping, which is unaffected. Left alone as a separate devops-gate decision.

## Testing Done

`make check` passes.

`resolve_mirror_urls()` was exercised before and after the change, sourcing `lib/common.sh` directly and resolving for each branch shape:

| `DEFAULT_GIT_BRANCH` | `DELPHIX_RELEASE_VERSION` | before | after |
|---|---|---|---|
| `develop` | 2026.5.0.0 | `-v2.../develop/3ce55a6a/ubuntu` | identical |
| `os-upgrade` | 9999.0.0.0 | `-v2.../os-upgrade/latest/ubuntu` | identical |
| `release/2026.4.0.0` | 2026.4.0.0 | `-v2.../releases/2026.4.0.0/ubuntu` | identical |
| `release/2025.2.0.1` | 2025.2.0.1 | `linux-package-mirror.../releases/...` | `-v2.../releases/...` |
| `develop` + env override | 2026.5.0.0 | `http://custom/ubuntu` | identical |

The only row that moves is the last release case, and it moves between two names for the same host, per the `getent` output above. The env-override path is untouched.

`os-upgrade` returns a 404 from the `latest/` lookup both before and after. That is the expected window where the branch's mirror has not been published yet, not a regression from this change.

### ab-pre-push build #14728: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14728/
- Tested: `linux-pkg@49b72d1` (against `develop`)
- Behind at recording: PR head is now `a9f99d6`, one commit past the tested SHA. The delta is the restoration of `compare_versions()`, a function definition with no callers, which cannot affect a build. (Point-in-time; not auto-updated, so confirm against the current head.)
- Status: running — result not yet available; re-run recording in completed mode once finished.

### Unrelated, noticed while testing

The `die` in the non-release lookup runs inside a command substitution, so it exits the subshell rather than the caller. A failed mirror lookup does not abort; it silently yields the 404 URL, which is why the `os-upgrade` case above still produced output. Pre-existing and out of scope here, but probably worth its own ticket.

## Related

- Noticed during review of #404


