### PR TITLE
DLPX-98274 fail the build when kernel module signing fails

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1567,13 +1567,19 @@ function sign_modules() {
 		temp_dir=$(mktemp -d -p "/var/tmp/")
 		logmust fakeroot dpkg-deb -R "$pkg" "$temp_dir"
 
-		# Find and sign all .ko files in package
-		find "$temp_dir" -type f -name "*.ko" -print0 |
-			while IFS= read -r -d '' kernel_mod; do
-				logmust kmodsign sha256 "$SBSIGN_KEY" "$SBSIGN_DER" "$kernel_mod" "$kernel_mod.signed"
-				logmust mv "$kernel_mod.signed" "$kernel_mod"
-				logmust modinfo -F signer "$kernel_mod"
-			done
+		#
+		# Find and sign all .ko files in package. The find output is fed
+		# in by process substitution rather than a pipe so that the loop
+		# body runs in this shell: in a pipeline it would run in a
+		# subshell, where logmust's die only exits the subshell and the
+		# package would go on to be repacked with unsigned modules.
+		#
+		while IFS= read -r -d '' kernel_mod; do
+			logmust kmodsign sha256 "$SBSIGN_KEY" "$SBSIGN_DER" "$kernel_mod" "$kernel_mod.signed"
+			logmust mv "$kernel_mod.signed" "$kernel_mod"
+			logmust modinfo -F signer "$kernel_mod"
+		done < <(find "$temp_dir" -type f -name "*.ko" -print0)
+
 		# Repack the .deb"
 		update_md5sums "$temp_dir"
 		repack_deb "$pkg" "$temp_dir"

--- a/setup.sh
+++ b/setup.sh
@@ -174,15 +174,15 @@ logmust sudo apt-get update
 #   -DKERNEL_CENTEVERSION= compiler flag and a cascade of unrelated-looking
 #   syntax errors deep in connstat.c's version-gated #if blocks.
 # - sbsigntool provides kmodsign, used by sign_modules() to sign kernel
-#   modules for packages like connstat and zfs. Without it, every module's
-#   kmodsign call fails with "command not found" inside sign_modules()'s
-#   find | while read loop; that loop runs in a subshell, so the failure
-#   is confined to it rather than aborting the build, and the resulting
-#   package silently ships an unsigned .ko instead of failing loudly.
-# - kmod provides modinfo, which sign_modules() also runs (after kmodsign,
-#   in the same subshelled loop) purely to log the signer's identity. Same
-#   silent-failure shape as kmodsign above, but this call doesn't mutate
-#   the module, so its absence doesn't affect the signature itself.
+#   modules for packages like connstat and zfs. Without it every module's
+#   kmodsign call fails with "command not found", which aborts the build.
+#   That used to pass silently and ship an unsigned .ko, because the signing
+#   loop ran in a subshell where logmust's die had no effect on the caller
+#   (DLPX-98274).
+# - kmod provides modinfo, which sign_modules() also runs after kmodsign,
+#   purely to log the signer's identity. It doesn't mutate the module, so
+#   its absence doesn't affect the signature itself, but it is a logmust
+#   call in the same loop, so a missing modinfo fails the build as well.
 # None of build-essential/debhelper/devscripts/equivs/fakeroot/git/wget are
 # part of debootstrap's --variant=buildd set, so they cannot be assumed
 # present.


### PR DESCRIPTION
[DLPX-98274](https://perforce.atlassian.net/browse/DLPX-98274)

## Problem

`sign_modules()` signs the `.ko` files in a package inside a `while read` loop fed by a pipe from `find`. That makes the loop body the last stage of a pipeline, so bash runs it in a subshell, and `logmust`'s `die` is an `exit` that only leaves that subshell. There is no `shopt -s lastpipe` anywhere in linux-pkg, and no `set -e` or `pipefail` on the path from `buildpkg.sh`, so the pipeline's exit status is never observed. `update_md5sums` and `repack_deb` then run unconditionally, repacking whatever happens to be on disk, and the function returns success.

Three failures get swallowed, and the third is the one that exists to catch the first two:

- `kmodsign` fails, so no `.signed` file is written
- `mv "$kernel_mod.signed" "$kernel_mod"` fails, so the module stays unsigned
- `modinfo -F signer` fails, i.e. the verification step cannot fail the build either

Further, since the subshell exits at the first failure, the remaining modules in that package are never attempted, yet the package is still repacked and published.

The outer loop over the package list in the same function is fed by a here-string (`done <<<"$deb_pkgs"`) rather than a pipe, so it runs in the current shell and its `logmust` calls do abort correctly. That asymmetry is what suggests the inner loop's subshell was accidental.

Callers are `packages/zfs/config.sh` and `packages/connstat/config.sh`. This is latent: it is not evidence that unsigned modules have shipped, it is evidence that if signing broke, the build would not say so. Where secure boot or kernel lockdown is enforced an unsigned module is refused at load time, so the failure would surface at boot on an engine rather than in CI.

## Solution

The solution taken in this PR is to feed the loop from process substitution instead of a pipe, so the body runs in the current shell and `logmust` aborts as intended. No logic change:

```bash
while IFS= read -r -d '' kernel_mod; do
	logmust kmodsign sha256 "$SBSIGN_KEY" "$SBSIGN_DER" "$kernel_mod" "$kernel_mod.signed"
	logmust mv "$kernel_mod.signed" "$kernel_mod"
	logmust modinfo -F signer "$kernel_mod"
done < <(find "$temp_dir" -type f -name "*.ko" -print0)
```

`setup.sh`'s comments on `sbsigntool` and `kmod` gave the old silent-failure behavior as the reason those packages matter, so they're updated to describe what happens now.

`release` is affected as well (the function body is byte-identical and neither branch sets `lastpipe`), and picks this up with the next release we cut.

## Test plan

`make shellcheck` and `make shfmtcheck` are clean on this branch.

Behavior was verified with a throwaway harness (deliberately not committed) that sources `lib/common.sh`, stubs `kmodsign`, `modinfo`, `dpkg-deb`, `fakeroot` and the S3 key fetch, and calls the real `sign_modules()`. It runs without `set -e`, since nothing on the production path enables errexit and errexit would abort on the failing pipeline by itself, masking the very thing under test. Each case was confirmed against the unfixed function first, then against the fix:

| case | before | after |
| --- | --- | --- |
| `kmodsign` exits nonzero | returns 0, package repacked | fails, package untouched |
| `kmodsign` exits 0 but writes no `.signed`, so `mv` fails | returns 0, package repacked | fails, package untouched |
| `modinfo -F signer` fails | returns 0, package repacked | fails, package untouched |
| all three succeed | repacks, both modules signed | unchanged |

The last row is the guard against over-fixing, and passed in both directions. Reverting only the `lib/common.sh` hunk takes the harness from pass back to fail, so it is discriminating on this change alone.

`verify-query-packages.sh` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Testing Done

### ab-pre-push build #14729: IN PROGRESS

- Build: https://selfservice-jenkins.eng-tools-prd.aws.delphixcloud.com/job/appliance-build-orchestrator-pre-push/14729/
- Tested: `linux-pkg@64a7511` (against `develop`); no other repo under test
- Status: running — result not yet available; re-run recording in completed mode once the build finishes.
