### PR TITLE
TOOL-30781 point linux-pkg's os-upgrade branch at the resolute suite

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -34,7 +34,7 @@ export JENKINS_OPS_DIR="${JENKINS_OPS_DIR:-jenkins-ops}"
 # The suite package builds run against, which may be different than the
 # branch's default (see lib/container.sh).
 #
-export UBUNTU_DISTRIBUTION="${UBUNTU_DISTRIBUTION:-noble}"
+export UBUNTU_DISTRIBUTION="${UBUNTU_DISTRIBUTION:-resolute}"
 
 source "$(dirname "${BASH_SOURCE[0]}")/container.sh"
 
@@ -1260,7 +1260,7 @@ function get_kernel_version_for_platform_from_apt() {
 	# available, it is not always the case.
 	#
 	if [[ "$platform" == generic ]]; then
-		package="linux-image-${platform}-hwe-24.04"
+		package="linux-image-${platform}-hwe-26.04"
 	else
 		package="linux-image-${platform}"
 	fi


### PR DESCRIPTION
<details open>
<summary><h2>Problem</h2></summary>

`linux-pkg`'s `os-upgrade` branch still defaults `UBUNTU_DISTRIBUTION` to `noble`, so every `linux-pkg/os-upgrade` job points apt at a suite the branch's mirror does not carry.

The mirror is no longer what's blocking. `os-upgrade/latest/` promoted on 2026-08-08 05:09 UTC (snapshot `8411ab44`) and publishes resolute, and only resolute:

```
ubuntu/dists/   resolute  resolute-backports  resolute-security  resolute-updates
ppas/dists/     resolute  resolute-pgdg  stable
```

with `ubuntu/dists/resolute/Release` reporting `Codename: resolute` / `Version: 26.04`. Since there are no `noble` suites under this branch, `configure_apt_sources()` writes `deb <mirror> noble ...` lines that resolve to nothing and the jobs die before they get as far as git:

```
E: The repository '.../os-upgrade/latest/ubuntu noble-backports Release' does not have a Release file.
Error: failed command 'sudo apt-get update'
```

The `generic` kernel lookup is pinned the same way; `get_kernel_version_for_platform_from_apt()` asks for `linux-image-generic-hwe-24.04`. That one does not hard-fail, which is what makes it worth catching now: resolute still publishes an `hwe-24.04` metapackage, and it depends on the same `7.0.0-14.14` kernel as `hwe-26.04`, so the stale pin resolves to the right kernel by accident and would not have announced itself for the rest of the cycle.

</details>

<details open>
<summary><h2>Solution</h2></summary>

The solution taken in this PR is to bump both pointers:

* `UBUNTU_DISTRIBUTION` default `noble` -> `resolute` in `lib/common.sh`. It stays environment-overridable (`${UBUNTU_DISTRIBUTION:-resolute}`, from TOOL-30719), so a build can still be aimed at another suite without editing the branch.
* the `generic` HWE metapackage `linux-image-generic-hwe-24.04` -> `-hwe-26.04`.

This targets `os-upgrade` rather than `develop`, since it cannot land on develop until the Phase 4 cutover. 24.04 analog: DLPX-91976 / #322.

The branch was re-reset to `develop` (`01b2d791e` -> `fef16a859`) before this change, since it had drifted behind again and was missing #408, #410, TOOL-30738 and #405. That reset is also what drops the `9999.0.0.0` mirror-host sentinel, so there is nothing separate to do for it here.

</details>

<details open>
<summary><h2>Testing Done</h2></summary>

* `make check` (shellcheck + shfmt) passes.
* The default resolves as intended and the environment override still wins:

```
(unset)                     -> resolute
UBUNTU_DISTRIBUTION=noble   -> noble
```

* Checked against the promoted mirror that every suite the new default asks for is actually published: `resolute{,-updates,-security,-backports}` under `ubuntu/`, and `resolute` + `resolute-pgdg` + `stable` under `ppas/`.
* Confirmed `linux-image-generic-hwe-26.04` exists in resolute (`7.0.0-14.14` in `resolute`, `7.0.0-29.29` in `resolute-updates`), so the new pin resolves.

No package build has been run against this yet. `build-packages` on `os-upgrade` is the next step and is where the real fallout is expected to show up; the intent is to fix-forward on the branch from there.

</details>
