### PR TITLE
TOOL-30798 track resolute's GA kernel for the generic flavor

### DIFF
--- a/default-package-config.sh
+++ b/default-package-config.sh
@@ -327,13 +327,17 @@ function kernel_update_upstream() {
 	# latest upstream tag to sync based on the kernel
 	# version and the ABI num that we got above.
 	#
-	# Note that "generic" (used mainly ESX) is a special
-	# case on bionic where we are using the HWE kernel image.
+	# Note that "generic" (used mainly ESX) carries no flavour
+	# segment in its tag name, since it is the suite's own
+	# kernel; e.g. 'Ubuntu-7.0.0-29.29'. An 'Ubuntu-hwe-*' tag
+	# only exists in the tree of the release receiving a
+	# backport, and never for that release's own GA kernel, so
+	# it does not apply while we track the GA kernel.
 	#
 	local tag_prefix_flavour
 	case "${platform}" in
 	generic)
-		tag_prefix_flavour="Ubuntu-hwe"
+		tag_prefix_flavour="Ubuntu"
 		;;
 	aws | azure | gcp | oracle)
 		tag_prefix_flavour="Ubuntu-${platform}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1253,17 +1253,16 @@ function get_kernel_version_for_platform_from_apt() {
 	# for kernel version '4.15.0-1027-aws'. We use this dependency to figure
 	# out the default kernel version for a given platform.
 	#
-	# The "generic" platform is a special case, since we want to use the
-	# hwe kernel image instead of the regular generic image.
+	# Every platform, "generic" included, tracks the GA kernel of the suite
+	# we are building for, rather than that suite's hwe image. At a fresh
+	# LTS the two resolve to the same kernel anyway, and the hwe git tags
+	# that update_upstream() needs do not exist in the new suite's tree
+	# yet; see TOOL-30798.
 	#
 	# Note that while the default kernel is usually also the latest
 	# available, it is not always the case.
 	#
-	if [[ "$platform" == generic ]]; then
-		package="linux-image-${platform}-hwe-26.04"
-	else
-		package="linux-image-${platform}"
-	fi
+	package="linux-image-${platform}"
 
 	if [[ "$(apt-cache show --no-all-versions "$package" \
 		2>/dev/null | grep Depends)" =~ linux-image-([^,]*-${platform}) ]]; then


### PR DESCRIPTION
<details open>
<summary><h2>Problem</h2></summary>

`linux-kernel-generic` is the one kernel flavor whose `upstreams/os-upgrade` has never been refreshed for resolute. It still sits on `Ubuntu-6.8.0-59.61` from 2025-04-11, i.e. noble's GA kernel from the 24.04 cycle, while `update-package` refreshed the other four this week:

```
linux-kernel-aws      Ubuntu-aws-7.0.0-1010.10     pushed 2026-08-09
linux-kernel-azure    Ubuntu-azure-7.0.0-1011.11   pushed 2026-08-09
linux-kernel-oracle   Ubuntu-oracle-7.0.0-1009.9   pushed 2026-08-09
linux-kernel-gcp      Ubuntu-gcp-7.0.0-1008.8      pushed 2026-08-10
linux-kernel-generic  Ubuntu-6.8.0-59.61           never pushed
```

`kernel_update_upstream()` treats `generic` as an HWE flavor (`tag_prefix_flavour="Ubuntu-hwe"`), paired with `get_kernel_version_for_platform_from_apt()` asking apt for `linux-image-generic-hwe-26.04`. The apt half resolves, so the version and ABI it computes are correct; #411 confirmed `7.0.0-14.14` in `resolute` and `7.0.0-29.29` in `resolute-updates`. The tag name built from them is not: it searches the resolute tree for `Ubuntu-hwe-7.0-7.0.0-29`, falls back to `Ubuntu-hwe-7.0.0-29`, matches neither, and dies before reaching the point where anything would be pushed. That is why the branch is untouched rather than half-advanced the way `makedumpfile` and `nfs-utils` were.

The resolute tree carries no `Ubuntu-hwe` tag at all, and that is expected rather than a Canonical policy change. An `Ubuntu-hwe-X.Y` tag only exists in the tree of the release receiving a backport, and never for that release's own GA kernel:

```
jammy    (GA 5.15)   Ubuntu-hwe-{5.17,5.19,6.2,6.5,6.8}
noble    (GA 6.8)    Ubuntu-hwe-{6.11,6.14,6.17,7.0}   and zero Ubuntu-hwe-6.8
resolute (GA 7.0)    none
```

noble's own 6.8 appears one release down, in jammy, as `Ubuntu-hwe-6.8-6.8.0-100.100_22.04.1`. resolute has nothing newer than 7.0 to backport into it yet; per Canonical, new installs only default to the HWE kernel from 26.04.2.

This is the second cycle it has bitten. The 24.04 cutover collapsed the same case to an unconditional `Ubuntu` prefix (`7e2bf0c`, DLPX-94086, 2025-05-12), which is why generic's `upstreams/os-upgrade` sits on a GA tag rather than an HWE one, and DLPX-95001 / #364 restored `Ubuntu-hwe` three months later (`98e143d`, 2025-08-04) once noble's HWE track had rolled to 6.11.

</details>

<details open>
<summary><h2>Solution</h2></summary>

The solution taken in this PR is to track the GA kernel of the suite being built for `generic`, the same way the other four flavors track theirs:

* `tag_prefix_flavour="Ubuntu"` in `kernel_update_upstream()`. The lookup lands via the existing fallback prefix, since Canonical tags a release's own kernel as `Ubuntu-<version>-<abi>.<upload>` with no series segment.
* `linux-image-generic` rather than `linux-image-generic-hwe-26.04` in `get_kernel_version_for_platform_from_apt()`, which removes the last `generic` special case there.

This is deliberately the 24.04 shape rather than a general fix. Once resolute's HWE track starts rolling at 26.04.2, `linux-image-generic-hwe-26.04` moves off the GA kernel and its backport does get tagged `Ubuntu-hwe-*` in the resolute tree, at which point this wants to go back the way DLPX-95001 took it. Arguably the better solution is to derive the prefix from the resolved version rather than hardcoding it (use `Ubuntu` when apt hands back the target suite's own GA kernel, `Ubuntu-hwe` otherwise), so that a third cycle does not repeat this. That is a larger change than the branch needs today, so I've opted for the narrow one for now; the follow-up that restores HWE after 26.04.2 can pick up the adaptive version.

The apt lookup has one other caller, `fetch_kernel_from_apt_for_platform()`, reached only by the `archive` kernel package source. `DEFAULT_LINUX_KERNEL_PACKAGE_SOURCE` is `delphix`, so that path is off by default, and on resolute both metapackages depend on the same kernel today, so what it would download is unchanged.

`os-upgrade` only. `develop` correctly uses the HWE kernel for generic, since noble's HWE track is live.

</details>

<details open>
<summary><h2>Testing Done</h2></summary>

`make check` (shellcheck + shfmt) passes.

Replicated the prefix construction from `kernel_update_upstream()` and resolved it against the real resolute tree (246 tags), for both ABIs apt can hand back (`7.0.0-14` from `resolute`, `7.0.0-29` from `resolute-updates`):

```
kver=7.0.0 abi=14 flavour=Ubuntu-hwe -> NO MATCH (tried Ubuntu-hwe-7.0-7.0.0-14 then Ubuntu-hwe-7.0.0-14) => die
kver=7.0.0 abi=14 flavour=Ubuntu     -> MATCH Ubuntu-7.0.0-14.14 (via Ubuntu-7.0.0-14)
kver=7.0.0 abi=29 flavour=Ubuntu-hwe -> NO MATCH (tried Ubuntu-hwe-7.0-7.0.0-29 then Ubuntu-hwe-7.0.0-29) => die
kver=7.0.0 abi=29 flavour=Ubuntu     -> MATCH Ubuntu-7.0.0-29.29 (via Ubuntu-7.0.0-29)
```

No `update-package` run yet. `linux-pkg/os-upgrade/update-package/linux-kernel-generic` is where this gets exercised for real, and the merge stage after it is expected to need hand conflict resolution the way `makedumpfile` and `nfs-utils` did.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
